### PR TITLE
update golang to 1.22.4 to fix CVE-2024-24788 CVE-2024-24790 CVE-2024…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 
-ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.22.4
+ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.22.5
 
 FROM --platform=$BUILDPLATFORM ${BUILDER} as builder
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 
-ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.22.2
+ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.22.4
 
 FROM --platform=$BUILDPLATFORM ${BUILDER} as builder
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com/eks/eks-pod-identity-agent
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com/eks/eks-pod-identity-agent
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1


### PR DESCRIPTION
…-24791

*Issue #, if available:*
update golang to 1.22.4 to fix CVE-2024-24788 CVE-2024-24790 CVE-2024-24791
*Description of changes:*
update golang to 1.22.4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
