### PR TITLE
fix: use common pod selector in metrics service

### DIFF
--- a/charts/eks-pod-identity-agent/templates/metrics.yaml
+++ b/charts/eks-pod-identity-agent/templates/metrics.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: eks-pod-identiy-agent
+    {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
       port: {{ .Values.metrics.port }}


### PR DESCRIPTION
*Issue #, if available:* 
- https://github.com/aws/eks-pod-identity-agent/issues/13

*Description of changes:*

Currently metrics service selector doesn't work, because it uses label `app` which is assigned to pods.
This change will use `{{- include "eks-pod-identity-agent.selectorLabels" . | nindent 4 }}` instead, same as daemon set does.

Code refernces:

- https://github.com/aws/eks-pod-identity-agent/blob/af723f6123d56b9aa4f555c5f6f478efca5138c0/charts/eks-pod-identity-agent/templates/daemonset.yaml#L11-L18

- https://github.com/aws/eks-pod-identity-agent/blob/af723f6123d56b9aa4f555c5f6f478efca5138c0/charts/eks-pod-identity-agent/templates/_helpers.tpl#L46-L52


-----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
