### PR TITLE
Add support to rotate credentials on hybrid nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 
 # Binaries
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
+HELM := $(TOOLS_BIN_DIR)/helm
+HELM_VERSION := v3.16.1
+
+$(TOOLS_BIN_DIR):
+	mkdir -p $(TOOLS_BIN_DIR)
+
+$(HELM): $(TOOLS_BIN_DIR)
+	@echo "Installing Helm $(HELM_VERSION)"
+	curl -sSL https://get.helm.sh/helm-$(HELM_VERSION)-$(GOOS)-$(GOARCH).tar.gz | tar -xzv -C $(TOOLS_BIN_DIR) --strip-components=1 $(GOOS)-$(GOARCH)/helm
 
 # Generic make
 REGISTRY_ID?=$(shell aws sts get-caller-identity | jq -r '.Account')
@@ -83,3 +92,8 @@ lint:
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.52.1; \
 	fi
 	golangci-lint run ./...
+
+.PHONY: helm-verify
+helm-verify: $(HELM)
+	$(HELM) lint charts/eks-pod-identity-agent
+	hack/scripts/helmverify.sh $(HELM)

--- a/charts/eks-pod-identity-agent/templates/_helpers.tpl
+++ b/charts/eks-pod-identity-agent/templates/_helpers.tpl
@@ -2,7 +2,8 @@
 Expand the name of the chart.
 */}}
 {{- define "eks-pod-identity-agent.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- include "addSuffixAndTrim" (dict "name" $name "suffix" .nameSuffix) -}}
 {{- end }}
 
 {{/*
@@ -11,15 +12,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "eks-pod-identity-agent.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- $name = .Values.fullnameOverride }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- if contains $name .Release.Name }}
+{{- $name = .Release.Name}}
+{{- else }}
+{{- $name = printf "%s-%s" .Release.Name $name }}
 {{- end }}
+{{- end }}
+{{- include "addSuffixAndTrim" (dict "name" $name "suffix" .nameSuffix) -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "addSuffixAndTrim" -}}
+{{- if .suffix -}}
+{{- $truncSize := int (sub 62 (len .suffix)) -}}
+{{- $trimmmedName := .name | trunc $truncSize | trimSuffix "-" -}}
+{{- printf "%s-%s" $trimmmedName .suffix -}}
+{{- else -}}
+{{- .name | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 {{- end }}
 

--- a/charts/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/charts/eks-pod-identity-agent/templates/daemonset.yaml
@@ -1,56 +1,63 @@
+{{- $top := . -}}
+{{- range $_, $daemonset := .Values.daemonsets -}}
+{{- if $daemonset.create -}}
+{{- $valuesDict := dict "nameSuffix" $daemonset.nameSuffix "Values" $top.Values "Release" $top.Release "Chart" $top.Chart -}}
+{{- $selectorLabels := include "eks-pod-identity-agent.selectorLabels" $valuesDict -}}
+{{- $affinity := default $top.Values.affinity $daemonset.affinity -}}
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "eks-pod-identity-agent.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "eks-pod-identity-agent.fullname" $valuesDict }}
+  namespace: {{ $top.Release.Namespace }}
   labels:
-    {{- include "eks-pod-identity-agent.labels" . | nindent 4 }}
+    {{- include "eks-pod-identity-agent.labels" $valuesDict | nindent 4}}
 spec:
   updateStrategy:
-    {{- toYaml .Values.updateStrategy | nindent 4 }}
+    {{- toYaml $top.Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
-      {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 6 }}
+      {{- $selectorLabels | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "eks-pod-identity-agent.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+        {{- $selectorLabels | nindent 8 }}
+        {{- with $top.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with $top.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      priorityClassName: {{ .Values.priorityClassName }}
+      priorityClassName: {{ $top.Values.priorityClassName }}
       hostNetwork: true
       terminationGracePeriodSeconds: 30
-      {{- with .Values.tolerations }}
+      {{- with $top.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with $top.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with $top.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.init.create }}
+      {{- if $top.Values.init.create }}
       initContainers:
-        - name: {{ .Chart.Name }}-init
-          image: {{ include "eks-pod-identity-agent.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: {{ .Values.init.command }}
-          {{- if .Values.init.additionalArgs }}
+        - name: {{ $top.Chart.Name }}-init
+          image: {{ include "eks-pod-identity-agent.image" $ }}
+          imagePullPolicy: {{ $top.Values.image.pullPolicy }}
+          command: {{ $top.Values.init.command }}
+          {{- if $top.Values.init.additionalArgs }}
           args:
-            {{- range $key, $value := .Values.init.additionalArgs }}
+            {{- range $key, $value := $top.Values.init.additionalArgs }}
             - {{ $key | quote }}
             - {{ $value | quote }}
             {{- end }}
@@ -59,22 +66,26 @@ spec:
             privileged: true
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
-          image: {{ include "eks-pod-identity-agent.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: {{ .Values.agent.command }}
+        - name: {{ $top.Chart.Name }}
+          image: {{ include "eks-pod-identity-agent.image" $ }}
+          imagePullPolicy: {{ $top.Values.image.pullPolicy }}
+          command: {{ $top.Values.agent.command }}
           args:
             - "--port"
             - "80"
             - "--cluster-name"
-            - {{ .Values.clusterName | quote }}
+            - {{ $top.Values.clusterName | quote }}
             - "--probe-port"
-            - {{ .Values.agent.probePort | quote }}
-            {{- if .Values.metrics.enabled }}
+            - {{ $top.Values.agent.probePort | quote }}
+            {{- if $top.Values.metrics.enabled }}
             - "--metrics-port"
-            - {{ .Values.metrics.port | quote }}
+            - {{ $top.Values.metrics.port | quote }}
             {{- end }}
-            {{- range $key, $value := .Values.agent.additionalArgs }}
+            {{- range $key, $value := $top.Values.agent.additionalArgs }}
+            - {{ $key | quote }}
+            - {{ $value | quote }}
+            {{- end }}
+            {{- range $key, $value := $daemonset.additionalArgs }}
             - {{ $key | quote }}
             - {{ $value | quote }}
             {{- end }}
@@ -82,44 +93,73 @@ spec:
             - containerPort: 80
               protocol: TCP
               name: proxy
-            - containerPort: {{ .Values.agent.probePort }}
+            - containerPort: {{ $top.Values.agent.probePort }}
               protocol: TCP
               name: probes-port
-           {{- if .Values.metrics.enabled }}
-            - containerPort: {{ .Values.metrics.port }}
+           {{- if $top.Values.metrics.enabled }}
+            - containerPort: {{ $top.Values.metrics.port }}
               protocol: TCP
               name: metrics
             {{- end }}
           env:
-          {{- range $key, $value := .Values.env }}
+          {{- range $key, $value := $top.Values.env }}
           - name: {{ $key }}
             value: {{ $value | quote }}
+          {{- end }}
+          {{- if contains "-iso" $top.Values.env.AWS_REGION }}
+          - name: AWS_CA_BUNDLE
+            value: /etc/pki/tls/certs/ca-bundle.crt
+          {{- end }}
+          {{- if or (contains "-iso" $top.Values.env.AWS_REGION) $daemonset.volumeMounts }}
+          volumeMounts:
+          {{- end }}
+          {{- if contains "-iso" $top.Values.env.AWS_REGION }}
+          - name: ca-bundle
+            mountPath: /etc/pki/tls/certs/ca-bundle.crt
+            readOnly: true
+          {{- end }}
+          {{- if $daemonset.volumeMounts }}
+          {{- toYaml $daemonset.volumeMounts | nindent 10}}
           {{- end }}
           securityContext:
             capabilities:
               add:
                 - CAP_NET_BIND_SERVICE
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.agent.livenessEndpoint }}
+            {{- toYaml $top.Values.resources | nindent 12 }}
+          {{- if $top.Values.agent.livenessEndpoint }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
               host: localhost
-              path: {{ .Values.agent.livenessEndpoint }}
+              path: {{ $top.Values.agent.livenessEndpoint }}
               port: probes-port
               scheme: HTTP
             initialDelaySeconds: 30
             timeoutSeconds: 10
           {{- end }}
-          {{- if .Values.agent.readinessEndpoint }}
+          {{- if $top.Values.agent.readinessEndpoint }}
           readinessProbe:
             failureThreshold: 30
             httpGet:
               host: localhost
-              path: {{ .Values.agent.readinessEndpoint }}
+              path: {{ $top.Values.agent.readinessEndpoint }}
               port: probes-port
               scheme: HTTP
             initialDelaySeconds: 1
             timeoutSeconds: 10
           {{- end }}
+      {{- if or (contains "-iso" $top.Values.env.AWS_REGION) $daemonset.volumes }}
+      volumes:
+      {{- end }}
+        {{- if contains "-iso" $top.Values.env.AWS_REGION }}
+        - name: ca-bundle
+          hostPath:
+            path: /etc/pki/tls/certs/ca-bundle.crt
+            type: File
+        {{- end }}
+        {{- if $daemonset.volumes }}
+        {{- toYaml $daemonset.volumes | nindent 8}}
+        {{- end }}
+{{ end }}
+{{ end }}

--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -2,6 +2,42 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+daemonsets:
+  cloud:
+    create: true
+  hybrid:
+    create: false
+    nameSuffix: hybrid
+    additionalArgs:
+      "--rotate-credentials": "true"
+    volumes:
+    - name: aws-credentials
+      hostPath:
+        path: /eks-hybrid/.aws
+        type: Directory
+    volumeMounts:
+    - mountPath: /root/.aws
+      name: aws-credentials
+      readOnly: true
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "kubernetes.io/os"
+                  operator: In
+                  values:
+                    - linux
+                - key: "kubernetes.io/arch"
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: "eks.amazonaws.com/compute-type"
+                  operator: In
+                  values:
+                    - hybrid
+
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -20,9 +56,12 @@ affinity:
               operator: NotIn
               values:
                 - fargate
+                - hybrid
+                - auto
 
 agent:
   additionalArgs:
+    "-v": "trace"
   command: "['/go-runner', '/eks-pod-identity-agent', 'server']"
   livenessEndpoint: /healthz
   probePort: 2703
@@ -62,6 +101,7 @@ imagePullSecrets: []
 
 init:
   additionalArgs:
+    "-v": "trace"
   command: "['/go-runner', '/eks-pod-identity-agent', 'initialize']"
   # Specifies whether initContainer should be created
   create: true

--- a/hack/scripts/helmverify.sh
+++ b/hack/scripts/helmverify.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+helm="$1"
+
+helm_template() {
+    local template_path=$1
+    local extra_args=$2
+
+    echo "Generating template for eks-pod-identity-agent at ${template_path}"
+    template=$(${helm} template ${extra_args} charts/eks-pod-identity-agent > ${template_path})
+}
+
+compare_templates() {
+    local generated_template_path=$1
+    local expected_template_path=$2
+
+    diff_output=$(diff -u ${expected_template_path} ${generated_template_path})
+    # Check if the diff output is empty
+    if [ -z "$diff_output" ]; then
+        echo "SUCCESS: No difference between ${expected_template_path} and ${generated_template_path}"
+    else
+        echo "ERROR: Difference found between ${expected_template_path} and ${generated_template_path}"
+        echo "$diff_output"
+        exit 1
+    fi
+}
+
+tmp_dir=$(mktemp -d)
+template_path=${tmp_dir}/template.yaml
+expected_default_template_path=hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
+expected_hybrid_template_path=hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
+
+echo "Validating default helm template for eks-pod-identity-agent"
+helm_template ${template_path}
+compare_templates ${template_path} ${expected_default_template_path}
+
+echo "Validating hybrid helm template for eks-pod-identity-agent"
+helm_template ${template_path} "--set daemonsets.hybrid.create=true
+    --set nameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated
+    --set fullnameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated"
+compare_templates ${template_path} ${expected_hybrid_template_path}
+
+rm -rf ${tmp_dir}

--- a/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
@@ -1,0 +1,111 @@
+---
+# Source: eks-pod-identity-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: eks-pod-identity-agent
+  namespace: default
+  labels:
+    helm.sh/chart: eks-pod-identity-agent-1.2.0
+    app.kubernetes.io/name: eks-pod-identity-agent
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "0.1.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eks-pod-identity-agent
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eks-pod-identity-agent
+        app.kubernetes.io/instance: release-name
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+                - hybrid
+                - auto
+      initContainers:
+        - name: eks-pod-identity-agent-init
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
+          args:
+            - "-v"
+            - "trace"
+          securityContext:
+            privileged: true
+      containers:
+        - name: eks-pod-identity-agent
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'server']
+          args:
+            - "--port"
+            - "80"
+            - "--cluster-name"
+            - "EKS_CLUSTER_NAME"
+            - "--probe-port"
+            - "2703"
+            - "-v"
+            - "trace"
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: proxy
+            - containerPort: 2703
+              protocol: TCP
+              name: probes-port
+          env:
+          - name: AWS_REGION
+            value: "AWS_REGION_NAME"
+          securityContext:
+            capabilities:
+              add:
+                - CAP_NET_BIND_SERVICE
+          resources:
+            {}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              host: localhost
+              path: /readyz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 1
+            timeoutSeconds: 10

--- a/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
+    app: eks-pod-identity-agent
 spec:
   updateStrategy:
     rollingUpdate:
@@ -25,6 +26,9 @@ spec:
       labels:
         app.kubernetes.io/name: eks-pod-identity-agent
         app.kubernetes.io/instance: release-name
+      annotations:
+        prometheus.io/port: "2705"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       hostNetwork: true
@@ -53,7 +57,7 @@ spec:
                 - auto
       initContainers:
         - name: eks-pod-identity-agent-init
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
           args:
@@ -63,7 +67,7 @@ spec:
             privileged: true
       containers:
         - name: eks-pod-identity-agent
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'server']
           args:

--- a/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
+    app: eks-pod-identity-agent
 spec:
   updateStrategy:
     rollingUpdate:
@@ -25,6 +26,9 @@ spec:
       labels:
         app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121321121
         app.kubernetes.io/instance: release-name
+      annotations:
+        prometheus.io/port: "2705"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       hostNetwork: true
@@ -53,7 +57,7 @@ spec:
                 - auto
       initContainers:
         - name: eks-pod-identity-agent-init
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
           args:
@@ -63,7 +67,7 @@ spec:
             privileged: true
       containers:
         - name: eks-pod-identity-agent
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'server']
           args:
@@ -122,6 +126,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
+    app: eks-pod-identity-agent
 spec:
   updateStrategy:
     rollingUpdate:
@@ -136,6 +141,9 @@ spec:
       labels:
         app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
         app.kubernetes.io/instance: release-name
+      annotations:
+        prometheus.io/port: "2705"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       hostNetwork: true
@@ -162,7 +170,7 @@ spec:
                 - hybrid
       initContainers:
         - name: eks-pod-identity-agent-init
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
           args:
@@ -172,7 +180,7 @@ spec:
             privileged: true
       containers:
         - name: eks-pod-identity-agent
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.10
           imagePullPolicy: Always
           command: ['/go-runner', '/eks-pod-identity-agent', 'server']
           args:

--- a/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
@@ -1,0 +1,231 @@
+---
+# Source: eks-pod-identity-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: eks-pod-identity-agent-custom-test-truncate-123213213121321121
+  namespace: default
+  labels:
+    helm.sh/chart: eks-pod-identity-agent-1.2.0
+    app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121321121
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "0.1.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121321121
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121321121
+        app.kubernetes.io/instance: release-name
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+                - hybrid
+                - auto
+      initContainers:
+        - name: eks-pod-identity-agent-init
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
+          args:
+            - "-v"
+            - "trace"
+          securityContext:
+            privileged: true
+      containers:
+        - name: eks-pod-identity-agent
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'server']
+          args:
+            - "--port"
+            - "80"
+            - "--cluster-name"
+            - "EKS_CLUSTER_NAME"
+            - "--probe-port"
+            - "2703"
+            - "-v"
+            - "trace"
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: proxy
+            - containerPort: 2703
+              protocol: TCP
+              name: probes-port
+          env:
+          - name: AWS_REGION
+            value: "AWS_REGION_NAME"
+          securityContext:
+            capabilities:
+              add:
+                - CAP_NET_BIND_SERVICE
+          resources:
+            {}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              host: localhost
+              path: /readyz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+---
+# Source: eks-pod-identity-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+  namespace: default
+  labels:
+    helm.sh/chart: eks-pod-identity-agent-1.2.0
+    app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "0.1.6"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+        app.kubernetes.io/instance: release-name
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: eks.amazonaws.com/compute-type
+                operator: In
+                values:
+                - hybrid
+      initContainers:
+        - name: eks-pod-identity-agent-init
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'initialize']
+          args:
+            - "-v"
+            - "trace"
+          securityContext:
+            privileged: true
+      containers:
+        - name: eks-pod-identity-agent
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.0.22
+          imagePullPolicy: Always
+          command: ['/go-runner', '/eks-pod-identity-agent', 'server']
+          args:
+            - "--port"
+            - "80"
+            - "--cluster-name"
+            - "EKS_CLUSTER_NAME"
+            - "--probe-port"
+            - "2703"
+            - "-v"
+            - "trace"
+            - "--rotate-credentials"
+            - "true"
+          ports:
+            - containerPort: 80
+              protocol: TCP
+              name: proxy
+            - containerPort: 2703
+              protocol: TCP
+              name: probes-port
+          env:
+          - name: AWS_REGION
+            value: "AWS_REGION_NAME"
+          volumeMounts:
+          - mountPath: /root/.aws
+            name: aws-credentials
+            readOnly: true
+          securityContext:
+            capabilities:
+              add:
+                - CAP_NET_BIND_SERVICE
+          resources:
+            {}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              host: localhost
+              path: /readyz
+              port: probes-port
+              scheme: HTTP
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+      volumes:
+        - hostPath:
+            path: /eks-hybrid/.aws
+            type: Directory
+          name: aws-credentials

--- a/internal/sharedcredsrotater/rotating_shared_credentials_provider.go
+++ b/internal/sharedcredsrotater/rotating_shared_credentials_provider.go
@@ -1,0 +1,57 @@
+package sharedcredsrotater
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+const (
+	defaultRotationInterval               = time.Minute
+	awsSharedCredentialsFileEnvVar        = "AWS_SHARED_CREDENTIALS_FILE"
+	rotatingSharedCredentialsProviderName = "RotatingSharedCredentialsProvider"
+)
+
+// RotatingSharedCredentialsProvider is a provider that retrieves credentials via the
+// shared credentials file, and adds the functionality of expiring and re-retrieving
+// those credentials from the file.
+type RotatingSharedCredentialsProvider struct {
+	// rotationInterval is the interval at which the credentials will be rotated.
+	rotationInterval time.Duration
+	// sharedCredentialsFiles is the list of shared credentials files to use.
+	sharedCredentialsFiles []string
+}
+
+// NewRotatingSharedCredentials returns a rotating shared credentials provider
+// with default values set.
+func NewRotatingSharedCredentialsProvider() *RotatingSharedCredentialsProvider {
+	credsFile := config.DefaultSharedCredentialsFiles
+	if cFile, ok := os.LookupEnv(awsSharedCredentialsFileEnvVar); ok {
+		credsFile = []string{cFile}
+	}
+	return &RotatingSharedCredentialsProvider{
+		rotationInterval:       defaultRotationInterval,
+		sharedCredentialsFiles: credsFile,
+	}
+}
+
+// Retrieve retrieves the credentials from the shared credentials file and returns it.
+func (p *RotatingSharedCredentialsProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	sharedConfig, err := config.LoadSharedConfigProfile(ctx, config.DefaultSharedConfigProfile, func(c *config.LoadSharedConfigOptions) {
+		c.ConfigFiles = []string{}
+		c.CredentialsFiles = p.sharedCredentialsFiles
+	})
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("loading shared credentials: %s", err)
+	}
+
+	creds := sharedConfig.Credentials
+	creds.Source = fmt.Sprintf("%s: %s", rotatingSharedCredentialsProviderName, p.sharedCredentialsFiles)
+	creds.CanExpire = true
+	creds.Expires = time.Now().Add(p.rotationInterval)
+	return creds, nil
+}

--- a/internal/sharedcredsrotater/rotating_shared_credentials_provider_test.go 
+++ b/internal/sharedcredsrotater/rotating_shared_credentials_provider_test.go 
@@ -1,0 +1,94 @@
+package sharedcredsrotater
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRotatingCredentialsProvider_FailCredsFileDoesNotExist(t *testing.T) {
+	b := make([]byte, 10)
+	rand.Read(b)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", fmt.Sprintf("/tmp/does-not-exist-%x", string(b)))
+	ctx := context.Background()
+	rcp := NewRotatingSharedCredentialsProvider()
+	cfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithCredentialsProvider(aws.NewCredentialsCache(rcp)),
+	)
+	assert.NoError(t, err)
+	v, err := cfg.Credentials.Retrieve(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, aws.Credentials{}, v)
+}
+
+func TestRotatingCredentialsProvider_RetrieveAndRefresh(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := os.CreateTemp(os.TempDir(), "credentials")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = ACCESSKEYID1
+aws_secret_access_key = ACCESSSECRET1
+aws_session_token = SESSIONTOKEN1
+`)
+	_, err = tmpFile.Write(text)
+	assert.NoError(t, err)
+
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpFile.Name())
+	ctx := context.Background()
+	rcp := NewRotatingSharedCredentialsProvider()
+	rcp.rotationInterval = time.Millisecond
+
+	cfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithCredentialsProvider(aws.NewCredentialsCache(rcp)),
+	)
+
+	assert.NoError(t, err)
+
+	v, err := cfg.Credentials.Retrieve(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s: [%s]", rotatingSharedCredentialsProviderName, tmpFile.Name()), v.Source)
+	assert.Equal(t, "ACCESSKEYID1", v.AccessKeyID)
+	assert.Equal(t, "ACCESSSECRET1", v.SecretAccessKey)
+	assert.Equal(t, "SESSIONTOKEN1", v.SessionToken)
+	assert.False(t, v.Expired(), "Credentials should not be expired yet")
+
+	// overwrite the credentials file and expect to receive the new creds
+	text2 := []byte(`[default]
+aws_access_key_id = ACCESSKEYID2
+aws_secret_access_key = ACCESSSECRET2
+aws_session_token = SESSIONTOKEN2
+`)
+
+	_, err = tmpFile.WriteAt(text2, 0)
+	assert.NoError(t, err)
+
+	// this should still retrieve the old creds from cache since they haven't expired yet
+	v, err = cfg.Credentials.Retrieve(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s: [%s]", rotatingSharedCredentialsProviderName, tmpFile.Name()), v.Source)
+	assert.Equal(t, "ACCESSKEYID1", v.AccessKeyID, "should still be the old creds")
+	assert.Equal(t, "ACCESSSECRET1", v.SecretAccessKey, "should still be the old creds")
+	assert.Equal(t, "SESSIONTOKEN1", v.SessionToken, "should still be the old creds")
+	assert.False(t, v.Expired(), "Credentials should not be expired yet")
+
+	time.Sleep(time.Millisecond)
+	assert.True(t, v.Expired(), "Credentials should be expired by now")
+
+	// this should retrieve the new creds since the old one in cache has expired
+	v, err = cfg.Credentials.Retrieve(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s: [%s]", rotatingSharedCredentialsProviderName, tmpFile.Name()), v.Source)
+	assert.Equal(t, "ACCESSKEYID2", v.AccessKeyID)
+	assert.Equal(t, "ACCESSSECRET2", v.SecretAccessKey)
+	assert.Equal(t, "SESSIONTOKEN2", v.SessionToken)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add support to rotate credentials on hybrid nodes.
- Add a new flag in pod identity agent `--rotate-credentials`. When this flag is set, it will configure the aws.Config with a rotating credentials provider which will rotate out the credentials every minute. This change is needed because hybrid nodes store temporary credentials in the shared credentials file (`/root/.aws/credentials`) but the default go SDK credentials chain does not rotate these shared credentials.
- This flag will only be set on hybrid node daemonset.
- Also add native support for eks pod identity agent by adding an additional daemonset that gets deployed specifically on hybrid nodes.

2. Also adds a new make target `make helm-verify` that validates that the generated helm template matches the expected one
```
✗ make helm-verify
Installing Helm v3.16.1
curl -sSL https://get.helm.sh/helm-v3.16.1-darwin-arm64.tar.gz | tar -xzv -C hack/tools/bin --strip-components=1 darwin-arm64/helm
x helm
hack/tools/bin/helm lint charts/eks-pod-identity-agent
==> Linting charts/eks-pod-identity-agent

1 chart(s) linted, 0 chart(s) failed
hack/scripts/helmverify.sh hack/tools/bin/helm
Validating default helm template for eks-pod-identity-agent
Generating template for eks-pod-identity-agent at /var/folders/nh/07z_l35173x8lt64qn530j4m0000gr/T/tmp.fQxEAwaHb4/template.yaml
SUCCESS: No difference between hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml and /var/folders/nh/07z_l35173x8lt64qn530j4m0000gr/T/tmp.fQxEAwaHb4/template.yaml
Validating hybrid helm template for eks-pod-identity-agent
Generating template for eks-pod-identity-agent at /var/folders/nh/07z_l35173x8lt64qn530j4m0000gr/T/tmp.fQxEAwaHb4/template.yaml
SUCCESS: No difference between hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml and /var/folders/nh/07z_l35173x8lt64qn530j4m0000gr/T/tmp.fQxEAwaHb4/template.yaml
```

3. Also adds an anti-affinity to not run on EKS Auto nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
