### PR TITLE
Dedupe concurrent active requests & pause on account throttling to minimize EKS Auth service calls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+# Github Action to create a release
+name: Create Release
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - version.txt
+
+jobs:
+  release:
+    if: ${{ github.repository == 'aws/eks-pod-identity-agent' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Tag release
+        run: |
+          /usr/bin/git config --global user.email actions@github.com
+          /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
+          hack/tag-release.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,3 @@ jobs:
       run: go mod tidy && go mod vendor && go test ./...
     - name: Verify helm template
       run: make helm-verify
-    - name: Tag release
-      run: |
-        /usr/bin/git config --global user.email actions@github.com
-        /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
-        hack/tag-release.sh

--- a/internal/credsretriever/refreshing_cache_test.go
+++ b/internal/credsretriever/refreshing_cache_test.go
@@ -461,7 +461,7 @@ func TestCachedCredentialRetriever_GetIamCredentials_ActiveRequestCaching(t *tes
 					func(ctx context.Context, request *credentials.EksCredentialsRequest) (*credentials.EksCredentialsResponse, credentials.ResponseMetadata, error) {
 						time.Sleep(200 * time.Millisecond) // Simulate API call latency
 						return nil, nil, fmt.Errorf("my special error")
-					}).Times(numRequests)
+					}).Times(1)
 			},
 			expectedErrMsg: "my special error",
 		},

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -58,6 +58,26 @@ func NewAccessDeniedError(reason string) *AccessDeniedError {
 	}
 }
 
+type ThrottledError struct {
+	Code    int
+	Message string
+}
+
+func (e *ThrottledError) Error() string {
+	return fmt.Sprintf("Too Many Requests. %s", e.Message)
+}
+
+func (e *ThrottledError) HttpStatus() int {
+	return e.Code
+}
+
+func NewThrottledError(reason string) *ThrottledError {
+	return &ThrottledError{
+		Message: reason,
+		Code:    http.StatusTooManyRequests,
+	}
+}
+
 func HandleCredentialFetchingError(ctx context.Context, err error) (string, int) {
 	log := logger.FromContext(ctx)
 	defer func() {


### PR DESCRIPTION
Dedupe concurrent active requests & pause on account throttling to minimize EKS Auth service calls

*Issue #, if available:* https://github.com/aws/eks-pod-identity-agent/issues/34

*Description of changes:*

> Dedupe concurrent active requests on the same service token, wait for the first request to finish cache, rather than making calls to EKS Auth service & cache to memory at the same time

This is achieved by an LRU cache of `internalActiveRequestCache`, when a `serviceAccountToken` is present in `internalActiveRequestCache`, it means there are multiple concurrent active requests on the same `serviceAccountToken`, in other words, other requests can wait a bit on the first one

> Pause calls to EKS Auth service for 1 sec when account is being throttled to avoid flooding requests to EKS Auth service to avoid further stress to the system

This is achieved by a cache of `internalThrottledRequestCache`, when account throttling happens, the default key is added into `internalThrottledRequestCache` with a 1 sec expiration

Unit tests are added to test the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
