### PR TITLE
Remove internalThrottledRequestCache

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -58,26 +58,6 @@ func NewAccessDeniedError(reason string) *AccessDeniedError {
 	}
 }
 
-type ThrottledError struct {
-	Code    int
-	Message string
-}
-
-func (e *ThrottledError) Error() string {
-	return fmt.Sprintf("Too Many Requests. %s", e.Message)
-}
-
-func (e *ThrottledError) HttpStatus() int {
-	return e.Code
-}
-
-func NewThrottledError(reason string) *ThrottledError {
-	return &ThrottledError{
-		Message: reason,
-		Code:    http.StatusTooManyRequests,
-	}
-}
-
 func HandleCredentialFetchingError(ctx context.Context, err error) (string, int) {
 	log := logger.FromContext(ctx)
 	defer func() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove internalThrottledRequestCache, since credential provider default retryer is no retry: https://javadoc.io/static/com.amazonaws/aws-java-sdk-osgi/1.11.665/com/amazonaws/retry/internal/CredentialsEndpointRetryPolicy.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
