### PR TITLE
Bump go version to 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 
-ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.22.5
+ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.23.5
 
 FROM --platform=$BUILDPLATFORM ${BUILDER} as builder
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com/eks/eks-pod-identity-agent
 
-go 1.22.5
+go 1.23.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1


### PR DESCRIPTION
*Issue #, if available:*

Bump go version to 1.23.5 to resolve multiple CVEs: CVE-2024-34156, CVE-2024-45336, CVE-2025-22866, CVE-2024-34158, CVE-2024-45341, CVE-2024-34155

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
