### PR TITLE
Add Bottlerocket hybrid node daemonset for Pod identity agent

### DIFF
--- a/charts/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/charts/eks-pod-identity-agent/templates/daemonset.yaml
@@ -125,6 +125,9 @@ spec:
             capabilities:
               add:
                 - CAP_NET_BIND_SERVICE
+            {{- with $daemonset.additionalSecurityContext }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml $top.Values.resources | nindent 12 }}
           {{- if $top.Values.agent.livenessEndpoint }}

--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -37,6 +37,49 @@ daemonsets:
                   operator: In
                   values:
                     - hybrid
+                - key: os.bottlerocket.aws/variant
+                  operator: DoesNotExist
+                - key: os.bottlerocket.aws/version
+                  operator: DoesNotExist
+  hybrid-bottlerocket:
+    create: false
+    nameSuffix: hybrid-bottlerocket
+    additionalArgs:
+      "--rotate-credentials": "true"
+    additionalSecurityContext:
+      seLinuxOptions:
+        type: spc_t
+    volumes:
+    - name: aws-credentials
+      hostPath:
+        path: /var/eks-hybrid/.aws
+        type: Directory
+    volumeMounts:
+    - mountPath: /root/.aws
+      name: aws-credentials
+      readOnly: true
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "kubernetes.io/os"
+                  operator: In
+                  values:
+                    - linux
+                - key: "kubernetes.io/arch"
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: "eks.amazonaws.com/compute-type"
+                  operator: In
+                  values:
+                    - hybrid
+                - key: os.bottlerocket.aws/variant
+                  operator: Exists
+                - key: os.bottlerocket.aws/version
+                  operator: Exists
 
 affinity:
   nodeAffinity:

--- a/hack/scripts/helmverify.sh
+++ b/hack/scripts/helmverify.sh
@@ -28,6 +28,7 @@ tmp_dir=$(mktemp -d)
 template_path=${tmp_dir}/template.yaml
 expected_default_template_path=hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
 expected_hybrid_template_path=hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
+expected_hybrid_bottlerocket_template_path=hack/testdata/expected_eks_pod_identity_agent_hybrid_bottlerocket_helm_template.yaml
 
 echo "Validating default helm template for eks-pod-identity-agent"
 helm_template ${template_path}
@@ -38,5 +39,11 @@ helm_template ${template_path} "--set daemonsets.hybrid.create=true
     --set nameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated
     --set fullnameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated"
 compare_templates ${template_path} ${expected_hybrid_template_path}
+
+echo "Validating Bottlerocket hybrid helm template for eks-pod-identity-agent"
+helm_template ${template_path} "--set daemonsets.hybrid-bottlerocket.create=true
+    --set nameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated
+    --set fullnameOverride=eks-pod-identity-agent-custom-test-truncate-123213213121321121-this-part-should-be-truncated"
+compare_templates ${template_path} ${expected_hybrid_bottlerocket_template_path}
 
 rm -rf ${tmp_dir}

--- a/hack/testdata/expected_eks_pod_identity_agent_hybrid_bottlerocket_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_hybrid_bottlerocket_helm_template.yaml
@@ -118,11 +118,11 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+  name: eks-pod-identity-agent-custom-test-truncate-hybrid-bottlerocket
   namespace: default
   labels:
     helm.sh/chart: eks-pod-identity-agent-1.2.0
-    app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+    app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-hybrid-bottlerocket
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
@@ -134,12 +134,12 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+      app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-hybrid-bottlerocket
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-123213213121-hybrid
+        app.kubernetes.io/name: eks-pod-identity-agent-custom-test-truncate-hybrid-bottlerocket
         app.kubernetes.io/instance: release-name
       annotations:
         prometheus.io/port: "2705"
@@ -169,9 +169,9 @@ spec:
                 values:
                 - hybrid
               - key: os.bottlerocket.aws/variant
-                operator: DoesNotExist
+                operator: Exists
               - key: os.bottlerocket.aws/version
-                operator: DoesNotExist
+                operator: Exists
       initContainers:
         - name: eks-pod-identity-agent-init
           image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:v0.1.20
@@ -216,6 +216,8 @@ spec:
             capabilities:
               add:
                 - CAP_NET_BIND_SERVICE
+            seLinuxOptions:
+              type: spc_t
           resources:
             {}
           livenessProbe:
@@ -238,6 +240,6 @@ spec:
             timeoutSeconds: 10
       volumes:
         - hostPath:
-            path: /eks-hybrid/.aws
+            path: /var/eks-hybrid/.aws
             type: Directory
           name: aws-credentials


### PR DESCRIPTION
This PR adds a new Pod Identity Agent `Daemonset` that will only be deployed on EKS Hybrid nodes running Bottlerocket OS. A couple of key changes from the default Hybrid nodes `Daemonset` are:
* securityContext: Bottlerocket has SELinux enabled by default, hence containers need privileged access to read mounted paths, such as `/root/.aws` for the credentials file. This is achieved by configurging it with the `spc_t` label.
* volume hostPath: Generally, the AWS credentials required for the `AssumeRoleForPodIdentity` API call are written to`/eks-hybrid/.aws` path on the host, which are then mounted to `/root/.aws` on the Pod Identity Agent container. However the `/eks-hybrid/.aws` path is not writeable on the Bottlerocket host since it's a readonly filesystem. Instead when bootstrapping the Bottlerocket node, we write the AWS credentials to the `/var/eks-hybrid/.aws` path, which will be mounted instead.
* Labels: Since we want the new `Daemonset` to only run on Bottlerocket nodes, we're adding new labels in the `nodeAffinity` section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
