### PR TITLE
bump go version in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 
-ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.23.5
+ARG BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.23.6
 
 FROM --platform=$BUILDPLATFORM ${BUILDER} as builder
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com/eks/eks-pod-identity-agent
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
bump go version version in docker file to fix [CVE-2025-22866](https://us-west-2.console.aws.amazon.com/inspector/v2/home?region=us-west-2#/findings?by=all&findingArn=arn:aws:inspector2:us-west-2:537017154062:finding/7d3cc455dc09e4feaa6a92ba57249072)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
