### PR TITLE
Tune wait time on active request cache and remove caching on error

### DIFF
--- a/internal/credsretriever/refreshing_cache_test.go
+++ b/internal/credsretriever/refreshing_cache_test.go
@@ -450,20 +450,6 @@ func TestCachedCredentialRetriever_GetIamCredentials_ActiveRequestCaching(t *tes
 				sampleResponseOne,
 			},
 		},
-		{
-			name: "calls with errors",
-			requests: []credentials.EksCredentialsRequest{
-				sampleRequestOne,
-			},
-			expectedDelegateCalls: func(delegate *mockcreds.MockCredentialRetriever) {
-				delegate.EXPECT().GetIamCredentials(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, request *credentials.EksCredentialsRequest) (*credentials.EksCredentialsResponse, credentials.ResponseMetadata, error) {
-						time.Sleep(200 * time.Millisecond) // Simulate API call latency
-						return nil, nil, fmt.Errorf("my special error")
-					}).Times(1)
-			},
-			expectedErrMsg: "my special error",
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Tune wait time on active request cache and remove caching on error, in the previous implementation, there was an ask in https://github.com/aws/eks-pod-identity-agent/pull/39#pullrequestreview-2540461585 to cache the error state. This is caching for 1 second, which makes a Pod to take longer time to come up when having error. When should remove this to let the Pod retry, especially when the Pod has customized retry and relies on aws api calls for health check.

Test has been done on the new image with regarding the time Pod can come up when keep retrying.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
