### PR TITLE
Use node instance role credentials for Pod Identity Agent as credenti…

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.amzn.com/eks/eks-pod-identity-agent/configuration"
 	"go.amzn.com/eks/eks-pod-identity-agent/internal/middleware/logger"
-	"go.amzn.com/eks/eks-pod-identity-agent/internal/sharedcredsrotater"
+	"go.amzn.com/eks/eks-pod-identity-agent/internal/credproviders"
 	"go.amzn.com/eks/eks-pod-identity-agent/pkg/handlers"
 	"go.amzn.com/eks/eks-pod-identity-agent/pkg/server"
 )
@@ -49,6 +49,7 @@ var serverCmd = &cobra.Command{
 		ctx := context.Background()
 		log := logger.FromContext(ctx)
 		cfg, err := config.LoadDefaultConfig(ctx)
+		cfg.Credentials = aws.NewCredentialsCache(credproviders.CustomDefaultCredentialsProvider(cfg))
 		if overrideEksAuthEndpoint != "" {
 			overrideEndpointInCfg(log, &cfg, overrideEksAuthEndpoint)
 		}
@@ -57,7 +58,7 @@ var serverCmd = &cobra.Command{
 		}
 		if rotateCredentials {
 			log.Info("Credentials rotation enabled. Creds will be fetched and rotated from shared credentials file")
-			cfg.Credentials = aws.NewCredentialsCache(sharedcredsrotater.NewRotatingSharedCredentialsProvider())
+			cfg.Credentials = aws.NewCredentialsCache(credproviders.NewRotatingSharedCredentialsProvider())
 		}
 
 		startServers(ctx, cfg)

--- a/internal/credproviders/custom_default_credentials_provider.go
+++ b/internal/credproviders/custom_default_credentials_provider.go
@@ -1,0 +1,57 @@
+package credproviders
+
+import (
+    "context"
+    "fmt"
+    "os"
+
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/credentials"
+    "github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
+    "github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+)
+
+// internal environment variable keys
+const (
+    envAWSAccessKeyID     = "AWS_ACCESS_KEY_ID"
+    envAWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+    envAWSSessionToken    = "AWS_SESSION_TOKEN"
+)
+
+// chainedProvider tries each provider in order until one succeeds
+type chainedProvider struct {
+    providers []aws.CredentialsProvider
+}
+
+func (c *chainedProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+    for _, p := range c.providers {
+        creds, err := p.Retrieve(ctx)
+        if err == nil {
+            return creds, nil
+        }
+    }
+    return aws.Credentials{}, fmt.Errorf("no valid credentials found in chained provider")
+}
+
+// CustomDefaultCredentialsProvider returns a provider that tries static env vars first, then IMDS
+func CustomDefaultCredentialsProvider(cfg aws.Config) aws.CredentialsProvider {
+    static := credentials.NewStaticCredentialsProvider(
+        os.Getenv(envAWSAccessKeyID),
+        os.Getenv(envAWSSecretAccessKey),
+        os.Getenv(envAWSSessionToken),
+    )
+
+    imdsClient := imds.NewFromConfig(cfg)
+    instanceProfile := ec2rolecreds.New(func(o *ec2rolecreds.Options) {
+        o.Client = imdsClient
+    })
+
+    chain := &chainedProvider{
+        providers: []aws.CredentialsProvider{
+            static,
+            instanceProfile,
+        },
+    }
+
+    return aws.NewCredentialsCache(chain)
+}

--- a/internal/credproviders/custom_default_credentials_provider_test.go
+++ b/internal/credproviders/custom_default_credentials_provider_test.go
@@ -1,0 +1,59 @@
+package credproviders
+
+import (
+    "context"
+    "os"
+    "testing"
+
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/credentials"
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestStaticCredsAvailable(t *testing.T) {
+    os.Setenv(envAWSAccessKeyID, "STATIC_KEY")
+    os.Setenv(envAWSSecretAccessKey, "STATIC_SECRET")
+    os.Setenv(envAWSSessionToken, "STATIC_TOKEN")
+    defer os.Unsetenv(envAWSAccessKeyID)
+    defer os.Unsetenv(envAWSSecretAccessKey)
+    defer os.Unsetenv(envAWSSessionToken)
+
+    cfg, err := config.LoadDefaultConfig(context.Background())
+    assert.NoError(t, err)
+
+    provider := CustomDefaultCredentialsProvider(cfg)
+    creds, err := provider.Retrieve(context.Background())
+    assert.NoError(t, err)
+
+    assert.Equal(t, "STATIC_KEY", creds.AccessKeyID)
+    assert.Equal(t, "STATIC_TOKEN", creds.SessionToken)
+    assert.Equal(t, "StaticCredentials", creds.Source)
+}
+
+func TestFallback(t *testing.T) {
+    os.Unsetenv(envAWSAccessKeyID)
+    os.Unsetenv(envAWSSecretAccessKey)
+    os.Unsetenv(envAWSSessionToken)
+
+    static := credentials.NewStaticCredentialsProvider(
+        os.Getenv(envAWSAccessKeyID),
+        os.Getenv(envAWSSecretAccessKey),
+        os.Getenv(envAWSSessionToken),
+    )
+
+    fallback := credentials.NewStaticCredentialsProvider("IMDS_KEY", "IMDS_SECRET", "IMDS_TOKEN")
+    cp := &chainedProvider{
+        providers: []aws.CredentialsProvider{
+            static,
+            fallback,
+        },
+    }
+
+    creds, err := cp.Retrieve(context.Background())
+    assert.NoError(t, err)
+
+    assert.Equal(t, "IMDS_KEY", creds.AccessKeyID)
+    assert.Equal(t, "IMDS_TOKEN", creds.SessionToken)
+    assert.Equal(t, "StaticCredentials", creds.Source)
+}

--- a/internal/credproviders/rotating_shared_credentials_provider.go
+++ b/internal/credproviders/rotating_shared_credentials_provider.go
@@ -1,4 +1,4 @@
-package sharedcredsrotater
+package credproviders
 
 import (
 	"context"

--- a/internal/credproviders/rotating_shared_credentials_provider_test.go 
+++ b/internal/credproviders/rotating_shared_credentials_provider_test.go 
@@ -1,4 +1,4 @@
-package sharedcredsrotater
+package credproviders
 
 import (
 	"context"


### PR DESCRIPTION
…al provider

*Issue #, if available:*

*Description of changes:*

Use node instance role credentials for Pod Identity Agent as credential provider

EKS Pod Identity is using the host network, IMDS will use node instance role as credential provider, which includes the permission to call assume-role-for-pod-identity.

We don't want container credential provider to take precedence over instance role credential provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
