### PR TITLE
disable automount service account token

### DIFF
--- a/charts/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/charts/eks-pod-identity-agent/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: false
       priorityClassName: {{ $top.Values.priorityClassName }}
       hostNetwork: true
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This daemonset doesn't connect to the kubernetes API server, disable automountServiceAccountToken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
