### PR TITLE
Set socket time and http request time out for EKS Auth client

### DIFF
--- a/internal/cloud/eksauth/service.go
+++ b/internal/cloud/eksauth/service.go
@@ -3,6 +3,8 @@ package eksauth
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,6 +27,16 @@ type service struct {
 }
 
 func NewService(cfg aws.Config) Iface {
+	// Configure HTTP client with custom timeouts
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: 500 * time.Millisecond, // Socket timeout
+			}).DialContext,
+		},
+		Timeout: 600 * time.Millisecond, // HTTP request timeout
+	}
+	cfg.HTTPClient = httpClient
 	eksAuthService := eksauth.NewFromConfig(cfg)
 	return &service{
 		eksAuthService: eksAuthService,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set socket timeout to 500ms, with request timeout to 600ms, this is applied on each try. By default, the AWS client will have 3 tries as standard retry strategy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
