### PR TITLE
metrics: fix pod_identity_cache_state(evicted) counter

### DIFF
--- a/internal/credsretriever/refreshing_cache.go
+++ b/internal/credsretriever/refreshing_cache.go
@@ -276,7 +276,6 @@ func (r *cachedCredentialRetriever) onCredentialRenewal(key string, entry cacheE
 			Infof("Credentials still valid for at least %0.2fs, keeping them will try again after ttl expires", oldCredsDuration.Seconds())
 		r.internalCache.SetWithRefreshExpire(key, entry, newRefreshTtl, oldCredsDuration)
 	} else {
-		promCacheState.WithLabelValues("evicted").Inc()
 		log.Infof("Evicting credentials since they are too old")
 	}
 }
@@ -284,6 +283,7 @@ func (r *cachedCredentialRetriever) onCredentialRenewal(key string, entry cacheE
 func (r *cachedCredentialRetriever) onCredentialEviction(key string, entry cacheEntry) {
 	log := logger.FromContext(entry.requestLogCtx)
 	log.Infof("Credentials evicted")
+	promCacheState.WithLabelValues("evicted").Inc()
 }
 
 func minDuration(a time.Duration, b time.Duration) time.Duration {


### PR DESCRIPTION
*Description of changes:*
Currently `pod_identity_cache_state(evicted)` is always 0 because it's not being incremented when actual eviction happens.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
