### PR TITLE
metrics: add error code label

### DIFF
--- a/internal/cloud/eksauth/errors.go
+++ b/internal/cloud/eksauth/errors.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/smithy-go"
 )
 
+const errCodeUnknown = "Unknown"
+
 func IsIrrecoverableApiError(err error) (string, bool) {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
@@ -20,5 +22,5 @@ func IsIrrecoverableApiError(err error) (string, bool) {
 			return ae.ErrorCode(), false
 		}
 	}
-	return "", false
+	return errCodeUnknown, false
 }

--- a/internal/cloud/eksauth/errors.go
+++ b/internal/cloud/eksauth/errors.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-func IsIrrecoverableApiError(err error) bool {
+func IsIrrecoverableApiError(err error) (string, bool) {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.(type) {
@@ -15,10 +15,10 @@ func IsIrrecoverableApiError(err error) bool {
 			*types.ExpiredTokenException,
 			*types.InvalidTokenException,
 			*types.AccessDeniedException:
-			return true
+			return ae.ErrorCode(), true
 		default:
-			return false
+			return ae.ErrorCode(), false
 		}
 	}
-	return false
+	return "", false
 }

--- a/internal/cloud/eksauth/errors_test.go
+++ b/internal/cloud/eksauth/errors_test.go
@@ -1,6 +1,7 @@
 package eksauth
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -50,6 +51,16 @@ func TestIsIrrecoverableApiError(t *testing.T) {
 				"AccessDeniedException",
 			},
 			expectedOk: true,
+		},
+		{
+			name: "unknown error",
+			errors: []error{
+				errors.New("custom error"),
+			},
+			expectedCodes: []string{
+				"Unknown",
+			},
+			expectedOk: false,
 		},
 	}
 

--- a/internal/credsretriever/refreshing_cache.go
+++ b/internal/credsretriever/refreshing_cache.go
@@ -63,7 +63,7 @@ var (
 	promCacheError = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pod_identity_cache_errors",
 		Help: "Removing credentials from cache, got non recoverable error",
-	}, []string{"type"},
+	}, []string{"type", "code"},
 	)
 
 	promCacheState = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -255,9 +255,9 @@ func (r *cachedCredentialRetriever) onCredentialRenewal(key string, entry cacheE
 			return
 		}
 
-		if eksauth.IsIrrecoverableApiError(err) {
+		if code, ok := eksauth.IsIrrecoverableApiError(err); ok {
 			log.Infof("Removing credentials from cache, got non recoverable error: %s", err.Error())
-			promCacheError.WithLabelValues("NonRecoverable").Inc()
+			promCacheError.WithLabelValues("NonRecoverable", code).Inc()
 			r.internalCache.Delete(entry.originatingRequest.ServiceAccountToken)
 			return
 		}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-pod-identity-agent/issues/13

*Description of changes:*

- Expose `NonRecoverable` error code as prometheus metric label
- Track `Recoverable` errors as metric