### PR TITLE
Add version info as cmd option and in logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ROOT_DIR_RELATIVE := .
 include $(ROOT_DIR_RELATIVE)/common.mk
 
+VERSION_FILE=version.txt
+
 # GIT_VERSION includes the latest git tag and is unique and not semver
 GIT_VERSION := $(shell git describe --tags --always)
 # GIT_VERSION_SHORT is only the latest git tag, not unique, semver
@@ -48,6 +50,7 @@ push: docker
 .PHONY: build
 build:
 	@echo "Building eks-pod-identity-agent for $(shell go env GOOS)/$(GOARCH)"
+	cp $(VERSION_FILE) configuration
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build \
 		-ldflags "-X 'k8s.io/component-base/version.gitVersion=$(GIT_VERSION_SHORT)' \
 		-X 'k8s.io/component-base/version.gitCommit=$(GIT_COMMIT_ID)' \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ROOT_DIR_RELATIVE := .
 include $(ROOT_DIR_RELATIVE)/common.mk
 
 VERSION_FILE=version.txt
+VERSION=$(shell cat $(VERSION_FILE))
 
 # GIT_VERSION includes the latest git tag and is unique and not semver
 GIT_VERSION := $(shell git describe --tags --always)
@@ -50,11 +51,11 @@ push: docker
 .PHONY: build
 build:
 	@echo "Building eks-pod-identity-agent for $(shell go env GOOS)/$(GOARCH)"
-	cp $(VERSION_FILE) configuration
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build \
 		-ldflags "-X 'k8s.io/component-base/version.gitVersion=$(GIT_VERSION_SHORT)' \
 		-X 'k8s.io/component-base/version.gitCommit=$(GIT_COMMIT_ID)' \
-		-X 'k8s.io/component-base/version/verflag.programName=eks-pod-identity-agent' " \
+		-X 'k8s.io/component-base/version/verflag.programName=eks-pod-identity-agent' \
+		-X 'go.amzn.com/eks/eks-pod-identity-agent/configuration.AgentVersion=$(VERSION)' " \
 		-o $(BINARY) .
 
 # Run the agent locally

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,27 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+        "go.amzn.com/eks/eks-pod-identity-agent/configuration"
+)
+
+var AgentVersion string = "v0.1.32"
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints agent version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("EKS Pod Identity Agent version %s\n",configuration.GetVersion())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,7 +10,7 @@ import (
 	"go.amzn.com/eks/eks-pod-identity-agent/configuration"
 )
 
-var AgentVersion string = "v0.1.32"
+var AgentVersion string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -8,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-        "go.amzn.com/eks/eks-pod-identity-agent/configuration"
+	"go.amzn.com/eks/eks-pod-identity-agent/configuration"
 )
 
 var AgentVersion string = "v0.1.32"
@@ -18,7 +17,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints agent version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("EKS Pod Identity Agent version %s\n",configuration.AgentVersion)
+		fmt.Printf("EKS Pod Identity Agent version %s\n", configuration.AgentVersion)
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints agent version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("EKS Pod Identity Agent version %s\n",configuration.GetVersion())
+		fmt.Printf("EKS Pod Identity Agent version %s\n",configuration.AgentVersion)
 	},
 }
 

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -1,10 +1,5 @@
 package configuration
 
-import (
-	_ "embed"
-	"strings"
-)
-
 const (
 	DefaultIpv6TargetHost = "fd00:ec2::23"
 	DefaultIpv4TargetHost = "169.254.170.23"
@@ -14,9 +9,4 @@ const (
 // RequestRate indicates the number of request allowed per second
 const RequestRate = 1000
 
-//go:embed "version.txt"
-var agentVersion string
-
-func GetVersion() string {
-	return strings.ReplaceAll(agentVersion,"\n","")
-}
+var AgentVersion string

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -1,5 +1,10 @@
 package configuration
 
+import (
+	_ "embed"
+	"strings"
+)
+
 const (
 	DefaultIpv6TargetHost = "fd00:ec2::23"
 	DefaultIpv4TargetHost = "169.254.170.23"
@@ -8,3 +13,10 @@ const (
 
 // RequestRate indicates the number of request allowed per second
 const RequestRate = 1000
+
+//go:embed "version.txt"
+var agentVersion string
+
+func GetVersion() string {
+	return strings.ReplaceAll(agentVersion,"\n","")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,6 +77,7 @@ func (p *Server) ListenUntilContextCancelled(ctx context.Context) {
 
 	// Run the server in a goroutine
 	go func() {
+                log.Infof("Pod Identity Agent version %v",configuration.GetVersion())
 		log.Info("Starting server...")
 		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Unable to start server: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,7 +77,7 @@ func (p *Server) ListenUntilContextCancelled(ctx context.Context) {
 
 	// Run the server in a goroutine
 	go func() {
-                log.Infof("Pod Identity Agent version %v",configuration.AgentVersion)
+		log.Infof("Pod Identity Agent version %v", configuration.AgentVersion)
 		log.Info("Starting server...")
 		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Unable to start server: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,7 +77,7 @@ func (p *Server) ListenUntilContextCancelled(ctx context.Context) {
 
 	// Run the server in a goroutine
 	go func() {
-                log.Infof("Pod Identity Agent version %v",configuration.GetVersion())
+                log.Infof("Pod Identity Agent version %v",configuration.AgentVersion)
 		log.Info("Starting server...")
 		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Unable to start server: %v", err)


### PR DESCRIPTION
Added version feature as requested in issue [Add a version command to binary and print the version string during startup #99](https://github.com/aws/eks-pod-identity-agent/issues/99).

Proposal looks like:

**Cmd**
```bash
# eks-pod-identity-agent version
2025/09/15 12:27:37 Setting logging verbosity level to: info (4)
EKS Pod Identity Agent version 0.1.33
```
**Logging**

```bash
# eks-pod-identity-agent server --metrics-address 127.0.0.1 --cluster-name <redacted> --bind-hosts 169.254.170.23 --port 80 --probe-port 2703 --verbosity info
2025/09/15 12:26:53 Setting logging verbosity level to: info (4)
{"bind-addr":"169.254.170.23:80","level":"info","msg":"Pod Identity Agent version 0.1.33","time":"2025-09-15T12:26:53+02:00"}
{"bind-addr":"169.254.170.23:80","level":"info","msg":"Starting server...","time":"2025-09-15T12:26:53+02:00"}
...
```