### PR TITLE
Extend http timeout to 1s (2 retries)

### DIFF
--- a/internal/cloud/eksauth/service.go
+++ b/internal/cloud/eksauth/service.go
@@ -34,7 +34,7 @@ func NewService(cfg aws.Config) Iface {
 				Timeout: 500 * time.Millisecond, // Socket timeout
 			}).DialContext,
 		},
-		Timeout: 600 * time.Millisecond, // HTTP request timeout
+		Timeout: 1000 * time.Millisecond, // HTTP request timeout
 	}
 	cfg.HTTPClient = httpClient
 	eksAuthService := eksauth.NewFromConfig(cfg)


### PR DESCRIPTION
600ms is too tight for agent to communicate with remote EKS auth service, especially for traffic over public Internet. this PR extends the timeout to 1s which effectively lowers down the retry count from 3 to 2 and increasing the per-retry timeout from 600ms to 1s.

/cc @haoranleo 