### PR TITLE
Make advertising port 80 optional

### DIFF
--- a/charts/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/charts/eks-pod-identity-agent/templates/daemonset.yaml
@@ -91,9 +91,11 @@ spec:
             - {{ $value | quote }}
             {{- end }}
           ports:
+            {{- if $top.Values.agent.advertiseProxyPort }}
             - containerPort: 80
               protocol: TCP
               name: proxy
+            {{- end }}
             - containerPort: {{ $top.Values.agent.probePort }}
               protocol: TCP
               name: probes-port

--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -105,6 +105,7 @@ affinity:
 agent:
   additionalArgs:
     "-v": "trace"
+  advertiseProxyPort: true
   command: "['/go-runner', '/eks-pod-identity-agent', 'server']"
   livenessEndpoint: /healthz
   probePort: 2703


### PR DESCRIPTION
*Issue #, if available:*

#10 

*Description of changes:*

eks-pod-identity-agent only bind on 169.254.170.23 and fd00:ec2::23 for port 80. By configuring the portmap cni plugin to exclude those 2 addresses
```
{
  "type": "portmap",
  "capabilities": {"portMappings": true},
  "snat": true,
  "conditionsV4": ['!', '-d', '169.254.170.23'],
  "conditionsV6": ['!', '-d', 'fd00:ec2::23']
}
```
we can have a pod using `hostPort: 80` (let's say ingress-nginx) and eks-pod-identity-agent running on the same node, we just need `advertiseProxyPort: false`.

see also https://github.com/aws/amazon-vpc-cni-k8s/issues/3497

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
