### PR TITLE
fix: support proxy from environment for HTTP client

### DIFF
--- a/internal/cloud/eksauth/service.go
+++ b/internal/cloud/eksauth/service.go
@@ -30,6 +30,7 @@ func NewService(cfg aws.Config) Iface {
 	// Configure HTTP client with custom timeouts
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout: 500 * time.Millisecond, // Socket timeout
 			}).DialContext,


### PR DESCRIPTION
*Issue #, if available:*
The [default proxy configuration from environment](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/transport/http/client.go#L184) was overridden in previous change https://github.com/aws/eks-pod-identity-agent/commit/c9106bb70ea6230cc50005840ea16efb84be3fb8, and the proxy configuration no longer works for pod identity new releases.

*Description of changes:*

Support proxy from environment for HTTP client

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
