### PR TITLE
Change credential cache key from JWT to Pod UID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/eksauth v1.11.7
 	github.com/aws/smithy-go v1.23.0
-	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/onsi/gomega v1.27.8
 	github.com/prometheus/client_golang v1.20.3
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=

--- a/internal/credsretriever/refreshing_cache_test.go
+++ b/internal/credsretriever/refreshing_cache_test.go
@@ -687,6 +687,7 @@ func TestCachedCredentialRetriever_AuthServiceFailure_NoCredentialsReturned(t *t
 	}
 	retriever := newCachedCredentialRetriever(opts)
 
+	// Pre-populate the cache with an entry for a pod UID using an initial JWT
 	podUID := "test-pod-uid-auth-failure"
 	initialTime := time.Now()
 	initialJWT := test.CreateToken(test.TokenConfig{
@@ -708,7 +709,7 @@ func TestCachedCredentialRetriever_AuthServiceFailure_NoCredentialsReturned(t *t
 	}
 	retriever.internalCache.Add(podUID, cachedEntry)
 
-	// Send a request coming from the same pod but with a different JWT
+	// Create a different JWT with the same pod UID (different iat/nbf/exp)
 	newTime := initialTime.Add(time.Minute)
 	newJWT := test.CreateToken(test.TokenConfig{
 		Expiry: newTime.Add(time.Hour),
@@ -717,15 +718,17 @@ func TestCachedCredentialRetriever_AuthServiceFailure_NoCredentialsReturned(t *t
 		PodUID: podUID,
 	})
 	g.Expect(newJWT).ToNot(Equal(initialJWT))
+
+	// Make a request with the new JWT
 	newRequest := &credentials.EksCredentialsRequest{
 		ServiceAccountToken: newJWT,
 	}
 
-	// Simulate a failure from the Auth Service
+	// The delegate (auth service) returns an error (InternalServerException)
 	delegate.EXPECT().GetIamCredentials(gomock.Any(), newRequest).
 		Return(nil, nil, &types.InternalServerException{}).Times(1)
 
-	// Exepct no credentials to have been returned, since the JWT cannot be validated
+	// Assert that no credentials are returned — the cached creds from the original JWT are not served
 	creds, _, err := retriever.GetIamCredentials(ctx, newRequest)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(creds).To(BeNil())

--- a/internal/validation/request.go
+++ b/internal/validation/request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/golang-jwt/jwt/v5"
-	_ "github.com/golang-jwt/jwt/v5"
 	"go.amzn.com/eks/eks-pod-identity-agent/configuration"
 	"go.amzn.com/eks/eks-pod-identity-agent/internal/middleware/logger"
 	"go.amzn.com/eks/eks-pod-identity-agent/pkg/credentials"

--- a/internal/validation/request_test.go
+++ b/internal/validation/request_test.go
@@ -32,33 +32,33 @@ func TestValidateEksCredentialRequest(t *testing.T) {
 		{
 			name: "passes on valid request",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrcAddr,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrcAddr,
 			},
 		},
 		{
 			name: "passes on valid request IPv6 no braces",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrc6Addr,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrc6Addr,
 			},
 		},
 		{
 			name: "passes on valid request IPv6 with braces",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrc6WithBraces,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrc6WithBraces,
 			},
 		},
 		{
 			name: "passes on valid request IPv6 with port",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrc6WithPort,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrc6WithPort,
 			},
 		},
 		{
@@ -73,27 +73,27 @@ func TestValidateEksCredentialRequest(t *testing.T) {
 		{
 			name: "no src add passed",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   "124.3.1.2",
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: "124.3.1.2",
 			},
 			error: fmt.Sprintf("Access Denied. Called agent through invalid address, please use either %s address not 124.3.1.2", defaultValidTargetHosts),
 		},
 		{
 			name: "expired token",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now(), time.Now(), time.Now()),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrcAddr,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now(), Iat: time.Now(), Nbf: time.Now()}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrcAddr,
 			},
 			error: "Service account token failed basic claim validations: token is expired",
 		},
 		{
 			name: "token nbf in future",
 			eksRequest: credentials.EksCredentialsRequest{
-				ServiceAccountToken: test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now().Add(1*time.Hour)),
-				ClusterName:         someValidClusterName,
-				RequestTargetHost:   someValidSrcAddr,
+				ServiceAccountToken: test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now().Add(1 * time.Hour)}),
+				ClusterName:       someValidClusterName,
+				RequestTargetHost: someValidSrcAddr,
 			},
 			error: "Service account token failed basic claim validations: token is not valid yet",
 		},

--- a/pkg/handlers/eks_credential_handler_test.go
+++ b/pkg/handlers/eks_credential_handler_test.go
@@ -46,7 +46,7 @@ func TestEksCredentialHandler_GetIamCredentialsHandler(t *testing.T) {
 	var (
 		validTargetHost              = configuration.DefaultIpv4TargetHost
 		someFutureTime               = time.Now().Add(1 * time.Hour)
-		someValidServiceAccountToken = test.CreateTokenForTest(someFutureTime, time.Now(), time.Now())
+		someValidServiceAccountToken = test.CreateToken(test.TokenConfig{Expiry: someFutureTime, Iat: time.Now(), Nbf: time.Now()})
 		validEksCredentialResponse   = &credentials.EksCredentialsResponse{
 			AccessKeyId:     "access-key-id",
 			SecretAccessKey: "secret-access-key",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -30,7 +30,7 @@ func TestEksCredentialServer(t *testing.T) {
 	)
 
 	var (
-		someValidServiceAccountToken = test.CreateTokenForTest(time.Now().Add(1*time.Hour), time.Now(), time.Now())
+		someValidServiceAccountToken = test.CreateToken(test.TokenConfig{Expiry: time.Now().Add(1 * time.Hour), Iat: time.Now(), Nbf: time.Now()})
 		getMockCredentials           = func() *credentials.EksCredentialsResponse {
 			expTime, _ := time.Parse(time.RFC3339Nano, "2023-07-13T20:49:35.999999999Z")
 			return &credentials.EksCredentialsResponse{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the internal cache to be keyed on the pod UID of a requesting pod rather than the JWT token itself. The pod UID is parsed from the incoming JWT token. The value of the cache entry will be unchanged.

This is to prepare for enhancements to static stability. Currently, credentials are keyed on the JWT. When a JWT rotates, the Auth Service must validate the new JWT and return credentials. However, if the Auth Service becomes unavailable during JWT rotation, the agent cannot validate the new JWT and doesn’t return credentials to the pod. The pod loses access to AWS resources even though valid credentials for the pod may exist in the cache, keyed on the old JWT. 

Addressing this issue requires two independent changes:
1. Change the PIA’s Cache Key from JWT Token to Pod UID. Since Pod UID remains constant throughout a pod's lifecycle, valid credentials will remain accessible even when JWT tokens rotate. 
2. Validate JWT tokens locally. This eliminates the dependency on the auth service for token validation, allowing rotated JWTs to access existing cached credentials even during auth service outages.

This PR addresses the first change. It does not solve the issue, but does not impact the existing functionality of the agent. 

*Testing:*
Unit testing - Created tests to verify the credential retrieval flow is not impacted by this change.
Manual testing - Verified that pods can still get credentials through request and renewal, even through JWT rotation. Let the pod run for 24 hours and confirmed via logs that credentials were renewed by the janitor process.

```
## Cache miss
# Incoming request
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"handling new request request from 192.168.132.105:51528","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"incoming podUID: 7ca1cd6a...","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"incoming serviceAccountToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImYyMTE...","time":"2026-01-14T18:07:51Z"}
# Current cache
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"existing cache:","time":"2026-01-14T18:07:51Z"}
# Fetching from delegate
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"Could not find entry in cache, requesting creds from delegate","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"Calling delegate and caching - pod UID is 7ca1cd6a-279a-441b-bdfe-4bee98b05c44","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"Calling EKS Auth to fetch credentials","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","fetched_role_arn":"arn:aws:sts::1234567890:assumed-role/...","fetched_role_id":"...","level":"info","msg":"Successfully fetched credentials from EKS Auth","request_time_ms":306,"time":"2026-01-14T18:07:51Z"}
# Updating cache
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"Storing creds in cache","refreshTtl":10800000000000,"time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"updated cache:","time":"2026-01-14T18:07:51Z"}
{"client-addr":"192.168.132.105:51528","cluster-name":"credtest3","level":"info","msg":"podUID: 7ca1cd6a...","time":"2026-01-14T18:07:51Z"}
```
```
## Cache hit
# Incoming request
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"handling new request request from 192.168.132.105:35378","time":"2026-01-14T18:17:54Z"}
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"incoming podUID: 7ca1cd6a...","time":"2026-01-14T18:17:54Z"}
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"incoming serviceAccountToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImYyMTE...","time":"2026-01-14T18:17:54Z"}
# Existing cache
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"existing cache:","time":"2026-01-14T18:17:54Z"}
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"podUID: 7ca1cd6a...","time":"2026-01-14T18:17:54Z"}
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"JWT token: eyJhbGciOiJSUzI1NiIsImtpZCI6ImYyMTE..","time":"2026-01-14T18:17:54Z"}
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"Internal cache hit - Pod UID and JWT are known","time":"2026-01-14T18:17:54Z"}
# Usage of cached credentials upon cache hit
{"client-addr":"192.168.132.105:35378","cluster-name":"credtest3","level":"info","msg":"Using cached credentials","time":"2026-01-14T18:17:54Z"}
```

This was previously merged into branch `cache-enhancements` through https://github.com/aws/eks-pod-identity-agent/pull/114. 