### PR TITLE
feat(pod-identity-agent): add JWK disk persistence

### DIFF
--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -5,6 +5,12 @@
 daemonsets:
   cloud:
     create: true
+    volumes:
+    - name: jwk-cache
+      emptyDir: {}
+    volumeMounts:
+    - mountPath: /var/lib/eks-pod-identity-agent
+      name: jwk-cache
   hybrid:
     create: false
     nameSuffix: hybrid

--- a/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_default_helm_template.yaml
@@ -90,6 +90,9 @@ spec:
           env:
           - name: AWS_REGION
             value: "AWS_REGION_NAME"
+          volumeMounts:
+          - mountPath: /var/lib/eks-pod-identity-agent
+            name: jwk-cache
           securityContext:
             capabilities:
               add:
@@ -114,3 +117,6 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 1
             timeoutSeconds: 10
+      volumes:
+        - emptyDir: {}
+          name: jwk-cache

--- a/hack/testdata/expected_eks_pod_identity_agent_hybrid_bottlerocket_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_hybrid_bottlerocket_helm_template.yaml
@@ -90,6 +90,9 @@ spec:
           env:
           - name: AWS_REGION
             value: "AWS_REGION_NAME"
+          volumeMounts:
+          - mountPath: /var/lib/eks-pod-identity-agent
+            name: jwk-cache
           securityContext:
             capabilities:
               add:
@@ -114,6 +117,9 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 1
             timeoutSeconds: 10
+      volumes:
+        - emptyDir: {}
+          name: jwk-cache
 ---
 # Source: eks-pod-identity-agent/templates/daemonset.yaml
 apiVersion: apps/v1

--- a/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
+++ b/hack/testdata/expected_eks_pod_identity_agent_hybrid_helm_template.yaml
@@ -90,6 +90,9 @@ spec:
           env:
           - name: AWS_REGION
             value: "AWS_REGION_NAME"
+          volumeMounts:
+          - mountPath: /var/lib/eks-pod-identity-agent
+            name: jwk-cache
           securityContext:
             capabilities:
               add:
@@ -114,6 +117,9 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 1
             timeoutSeconds: 10
+      volumes:
+        - emptyDir: {}
+          name: jwk-cache
 ---
 # Source: eks-pod-identity-agent/templates/daemonset.yaml
 apiVersion: apps/v1

--- a/internal/validation/jwk_store.go
+++ b/internal/validation/jwk_store.go
@@ -1,0 +1,66 @@
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const defaultJWKCachePath = "/var/lib/eks-pod-identity-agent/jwks-cache.json"
+
+// cacheDirPerm is the permission for the cache directory (owner rwx only).
+const cacheDirPerm = os.FileMode(0700)
+
+// writeJWKCache atomically writes a JWKSet to disk using a temp file + rename
+// for crash safety. The parent directory is created if it doesn't exist.
+func writeJWKCache(path string, jwks *JWKSet) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, cacheDirPerm); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	data, err := json.Marshal(jwks)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JWKSet: %w", err)
+	}
+
+	// Create temp file in the same directory
+	f, err := os.CreateTemp(dir, ".jwks-cache-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer f.Close() // safety net in case a panic skips the explicit closes below
+	tmp := f.Name()
+
+	// Write data to temp file; close + remove on failure to avoid fd/file leaks.
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	// Close before rename so data is fully flushed to disk.
+	f.Close()
+
+	// Atomic rename — readers see old or new file, never partial data.
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+	return nil
+}
+
+// readJWKCache reads and unmarshals a JWKSet from disk.
+func readJWKCache(path string) (*JWKSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	var jwks JWKSet
+	if err := json.Unmarshal(data, &jwks); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cache file: %w", err)
+	}
+	return &jwks, nil
+}

--- a/internal/validation/jwk_store_test.go
+++ b/internal/validation/jwk_store_test.go
@@ -1,0 +1,151 @@
+package validation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"go.amzn.com/eks/eks-pod-identity-agent/internal/test"
+)
+
+// TestJWKDiskPersistence_WriteAndRead_RoundTrips verifies that a JWKSet written to disk
+// can be read back with all key fields intact.
+func TestJWKDiskPersistence_WriteAndRead_RoundTrips(t *testing.T) {
+	g := NewWithT(t)
+	key := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+
+	path := filepath.Join(t.TempDir(), "jwks-cache.json")
+	err := writeJWKCache(path, jwks)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := readJWKCache(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got.Keys).To(HaveLen(1))
+	g.Expect(got.Keys[0].Kid).To(Equal("kid-1"))
+	g.Expect(got.Keys[0].Kty).To(Equal("RSA"))
+	g.Expect(got.Keys[0].N).To(Equal(jwks.Keys[0].N))
+	g.Expect(got.Keys[0].E).To(Equal(jwks.Keys[0].E))
+}
+
+// TestReadJWKCache_ErrorCases verifies that readJWKCache returns descriptive errors
+// for corrupt and missing cache files rather than panicking.
+func TestReadJWKCache_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantError string
+	}{
+		{
+			name: "corrupt file",
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "jwks-cache.json")
+				os.WriteFile(path, []byte("not valid json{{{"), 0600)
+				return path
+			},
+			wantError: "failed to unmarshal cache file",
+		},
+		{
+			name: "missing file",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "nonexistent.json")
+			},
+			wantError: "failed to read cache file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			path := tt.setup(t)
+			_, err := readJWKCache(path)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.wantError))
+		})
+	}
+}
+
+// TestJWKDiskPersistence_FilePermissions_0600 verifies that the cache file is written
+// with restrictive permissions (owner read/write only).
+func TestJWKDiskPersistence_FilePermissions_0600(t *testing.T) {
+	g := NewWithT(t)
+	key := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+
+	path := filepath.Join(t.TempDir(), "jwks-cache.json")
+	err := writeJWKCache(path, jwks)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	info, err := os.Stat(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info.Mode().Perm()).To(Equal(os.FileMode(0600)))
+}
+
+// TestJWKDiskPersistence_RestartFileIntegrity verifies that the file content is
+// byte-identical when read back after a simulated agent restart (new process reads
+// the same file written by the previous process).
+func TestJWKDiskPersistence_RestartFileIntegrity(t *testing.T) {
+	g := NewWithT(t)
+	key := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+
+	path := filepath.Join(t.TempDir(), "jwks-cache.json")
+
+	// "First boot" writes the file
+	err := writeJWKCache(path, jwks)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Capture raw bytes written to disk
+	original, err := os.ReadFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// "Restart" — read the file back as a new process would
+	reloaded, err := os.ReadFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(reloaded).To(Equal(original), "file content must be byte-identical after restart")
+
+	// Also verify the deserialized keys match
+	got, err := readJWKCache(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got.Keys).To(HaveLen(1))
+	g.Expect(got.Keys[0].Kid).To(Equal("kid-1"))
+	g.Expect(got.Keys[0].N).To(Equal(jwks.Keys[0].N))
+	g.Expect(got.Keys[0].E).To(Equal(jwks.Keys[0].E))
+}
+
+// TestJWKDiskPersistence_PodDeletion_EmptyDirSemantics verifies that when the cache
+// directory is removed (simulating pod deletion with emptyDir volume or container
+// ephemeral storage), readJWKCache returns a clear error and writeJWKCache can
+// recreate the directory structure from scratch.
+func TestJWKDiskPersistence_PodDeletion_EmptyDirSemantics(t *testing.T) {
+	g := NewWithT(t)
+	key := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "run", "eks-pod-identity-agent")
+	path := filepath.Join(cacheDir, "jwks-cache.json")
+
+	// Write cache (creates directory)
+	err := writeJWKCache(path, jwks)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Simulate pod deletion: remove the entire directory tree
+	err = os.RemoveAll(cacheDir)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Read should fail gracefully (no panic)
+	_, err = readJWKCache(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to read cache file"))
+
+	// New pod starts: writeJWKCache recreates the directory and file
+	err = writeJWKCache(path, jwks)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := readJWKCache(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got.Keys).To(HaveLen(1))
+}

--- a/internal/validation/token_validator.go
+++ b/internal/validation/token_validator.go
@@ -25,6 +25,7 @@ type TokenValidator struct {
 	keys            atomic.Value // stores keyCache, which maps key IDs (kid) to public keys
 	jwksSource      jwksProvider
 	refreshInFlight atomic.Bool
+	jwkCachePath    string // disk path for persisting JWKS between restarts
 }
 
 func NewTokenValidator(ctx context.Context) (*TokenValidator, error) {
@@ -32,8 +33,9 @@ func NewTokenValidator(ctx context.Context) (*TokenValidator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize apiserver client: %w", err)
 	}
-	tv := &TokenValidator{jwksSource: ac}
+	tv := &TokenValidator{jwksSource: ac, jwkCachePath: defaultJWKCachePath}
 	tv.keys.Store(make(keyCache))
+
 	go func() {
 		// pre-populate the cache, but do not return an error on failure
 		// cache misses should trigger a refresh on the next request
@@ -70,7 +72,7 @@ func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.Ek
 	if req.ServiceAccountToken == "" {
 		return errors.NewRequestValidationError("Service account token cannot be empty")
 	}
-	
+
 	parsedToken, _, err := jwt.NewParser().ParseUnverified(req.ServiceAccountToken, jwt.MapClaims{})
 	if err != nil {
 		return errors.NewRequestValidationError(fmt.Sprintf("Service account token cannot be parsed: %v", err))
@@ -87,7 +89,10 @@ func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.Ek
 	return nil
 }
 
-// refreshKeys fetches JWKS from the API server and refreshes the internal cache.
+// refreshKeys attempts to fetch JWKS from the apiserver and load them into the
+// in-memory cache. On success, keys are also persisted to disk. If the apiserver
+// is unreachable, it falls back to the last-known-good keys from the disk cache,
+// ensuring the agent can continue validating tokens across restarts and outages.
 func (tv *TokenValidator) refreshKeys(ctx context.Context) error {
 	if !tv.refreshInFlight.CompareAndSwap(false, true) {
 		return fmt.Errorf("key refresh already in progress")
@@ -98,10 +103,40 @@ func (tv *TokenValidator) refreshKeys(ctx context.Context) error {
 	log.Infof("Public key cache refresh triggered")
 	jwks, err := tv.jwksSource.fetchPublicKeys(ctx)
 	if err != nil {
-		return err
+		return tv.loadKeysFromDisk(ctx, err)
 	}
+
+	tv.persistKeys(ctx, jwks)
 	tv.loadJWKSet(ctx, jwks)
 	return nil
+}
+
+// loadKeysFromDisk attempts to load keys from the disk cache when the apiserver
+// is unreachable. Returns the original fetch error if the disk fallback also fails.
+func (tv *TokenValidator) loadKeysFromDisk(ctx context.Context, fetchErr error) error {
+	log := logger.FromContext(ctx)
+	if tv.jwkCachePath == "" {
+		return fetchErr
+	}
+	cached, err := readJWKCache(tv.jwkCachePath)
+	if err != nil {
+		log.Warnf("failed to load JWK cache from disk: %v", err)
+		return fetchErr
+	}
+	log.Warnf("apiserver fetch failed, loaded keys from disk cache: %v", fetchErr)
+	tv.loadJWKSet(ctx, cached)
+	return nil
+}
+
+// persistKeys writes the JWKSet to disk for future fallback use.
+func (tv *TokenValidator) persistKeys(ctx context.Context, jwks *JWKSet) {
+	if tv.jwkCachePath == "" {
+		return
+	}
+	if err := writeJWKCache(tv.jwkCachePath, jwks); err != nil {
+		log := logger.FromContext(ctx)
+		log.Warnf("failed to write JWK cache to disk: %v", err)
+	}
 }
 
 // loadJWKSet parses a JWKSet and atomically replaces the key cache.

--- a/internal/validation/token_validator_test.go
+++ b/internal/validation/token_validator_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -417,9 +418,9 @@ func TestValidateToken_K8sVersionGating(t *testing.T) {
 	jwksResponse := JWKSet{Keys: []JWK{rsaJWK(test.DefaultKid, &signingKey.PublicKey)}}
 
 	tests := []struct {
-		name    string
-		version map[string]string
-		wantErr bool
+		name     string
+		version  map[string]string
+		wantErr  bool
 		closeSrv bool
 	}{
 		{
@@ -471,4 +472,206 @@ func TestValidateToken_K8sVersionGating(t *testing.T) {
 			}
 		})
 	}
+}
+
+// failingJWKSProvider always returns an error from fetchPublicKeys,
+// simulating an unreachable apiserver.
+type failingJWKSProvider struct{}
+
+func (f *failingJWKSProvider) fetchPublicKeys(_ context.Context) (*JWKSet, error) {
+	return nil, fmt.Errorf("apiserver unreachable")
+}
+
+// TestRefreshKeys_DiskPersistence covers all interactions between refreshKeys and the
+// disk cache: persist on success, fallback on failure, graceful handling of write errors.
+func TestRefreshKeys_DiskPersistence(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerFails  bool   // whether the jwksProvider returns an error
+		preSeedDisk    bool   // whether to write a cache file before calling refreshKeys
+		cachePath      string // override cache path ("" = no path, "nested" = subdir, "unwritable" = /proc/fake)
+		wantErr        bool
+		wantKeysInMem  bool
+		wantKeysOnDisk bool
+	}{
+		{
+			name:           "apiserver up, persists to disk",
+			providerFails:  false,
+			preSeedDisk:    false,
+			cachePath:      "normal",
+			wantKeysInMem:  true,
+			wantKeysOnDisk: true,
+		},
+		{
+			name:           "apiserver up, auto-creates nested directory",
+			providerFails:  false,
+			preSeedDisk:    false,
+			cachePath:      "nested",
+			wantKeysInMem:  true,
+			wantKeysOnDisk: true,
+		},
+		{
+			name:           "apiserver up, disk write fails, keys still loaded",
+			providerFails:  false,
+			preSeedDisk:    false,
+			cachePath:      "unwritable",
+			wantKeysInMem:  true,
+			wantKeysOnDisk: false,
+		},
+		{
+			name:           "apiserver down, falls back to disk cache",
+			providerFails:  true,
+			preSeedDisk:    true,
+			cachePath:      "normal",
+			wantKeysInMem:  true,
+			wantKeysOnDisk: true, // already on disk from pre-seed
+		},
+		{
+			name:          "apiserver down, no disk cache, returns error",
+			providerFails: true,
+			preSeedDisk:   false,
+			cachePath:     "normal",
+			wantErr:       true,
+			wantKeysInMem: false,
+		},
+		{
+			name:          "apiserver down, no cache path configured, returns error",
+			providerFails: true,
+			preSeedDisk:   false,
+			cachePath:     "",
+			wantErr:       true,
+			wantKeysInMem: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			key := test.GenerateTestKey(t)
+			jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+
+			// Resolve the cache path
+			var path string
+			switch tt.cachePath {
+			case "normal":
+				path = filepath.Join(t.TempDir(), "jwks-cache.json")
+			case "nested":
+				path = filepath.Join(t.TempDir(), "sub", "dir", "jwks-cache.json")
+			case "unwritable":
+				path = "/proc/fake/jwks-cache.json"
+			case "":
+				path = ""
+			}
+
+			// Pre-seed disk if needed
+			if tt.preSeedDisk && path != "" {
+				g.Expect(writeJWKCache(path, jwks)).To(Succeed())
+			}
+
+			// Set up provider
+			var source jwksProvider
+			if tt.providerFails {
+				source = &failingJWKSProvider{}
+			} else {
+				source = &channelJWKSProvider{called: make(chan struct{}, 1), jwks: jwks}
+			}
+
+			tv := &TokenValidator{jwksSource: source, jwkCachePath: path}
+			tv.keys.Store(make(keyCache))
+
+			err := tv.refreshKeys(context.Background())
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Check in-memory keys
+			cache := tv.keys.Load().(keyCache)
+			if tt.wantKeysInMem {
+				g.Expect(cache).To(HaveKey("kid-1"))
+			} else {
+				g.Expect(cache).To(BeEmpty())
+			}
+
+			// Check disk keys
+			if tt.wantKeysOnDisk && path != "" {
+				got, err := readJWKCache(path)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(got.Keys).To(HaveLen(1))
+			}
+		})
+	}
+}
+
+// TestRefreshKeys_AlreadyInFlight verifies that concurrent refresh attempts
+// are rejected with an error rather than blocking or double-fetching.
+func TestRefreshKeys_AlreadyInFlight(t *testing.T) {
+	g := NewWithT(t)
+	tv := &TokenValidator{}
+	tv.keys.Store(make(keyCache))
+	tv.refreshInFlight.Store(true)
+
+	err := tv.refreshKeys(context.Background())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("already in progress"))
+}
+
+// TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache simulates a full
+// agent lifecycle: fetch keys → persist to disk → restart with apiserver down →
+// validate a token using only the disk-cached keys.
+func TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	kid := "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+	signingKey := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK(kid, &signingKey.PublicKey)}}
+	cachePath := filepath.Join(t.TempDir(), "jwks-cache.json")
+
+	// --- First boot: apiserver is up, keys fetched and persisted ---
+	provider := &channelJWKSProvider{called: make(chan struct{}, 1), jwks: jwks}
+	tv1 := &TokenValidator{jwksSource: provider, jwkCachePath: cachePath}
+	tv1.keys.Store(make(keyCache))
+
+	err := tv1.refreshKeys(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tv1.keys.Load().(keyCache)).To(HaveKey(kid))
+
+	// --- Simulate restart: new validator, apiserver is down ---
+	tv2 := &TokenValidator{jwksSource: &failingJWKSProvider{}, jwkCachePath: cachePath}
+	tv2.keys.Store(make(keyCache))
+
+	err = tv2.refreshKeys(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// --- Validate a token signed with the original key ---
+	now := time.Now()
+	token := test.CreateSignedToken(t, signingKey, test.TokenConfig{
+		Expiry: now.Add(time.Hour),
+		Iat:    now,
+		Nbf:    now,
+		Overrides: map[string]interface{}{
+			"sub": "system:serviceaccount:default:my-sa",
+			"kubernetes.io": map[string]interface{}{
+				"namespace": "default",
+				"pod": map[string]interface{}{
+					"name": "my-pod",
+					"uid":  "pod-uid",
+				},
+				"serviceaccount": map[string]interface{}{
+					"name": "my-sa",
+					"uid":  "sa-uid",
+				},
+			},
+		},
+		HeaderOverrides: map[string]interface{}{"kid": kid},
+	})
+
+	// Full ValidateToken: claims + signature verification using disk-cached keys
+	err = tv2.ValidateToken(ctx, &credentials.EksCredentialsRequest{
+		ServiceAccountToken: token,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
 }


### PR DESCRIPTION
Note: Internally approved in https://github.com/gargipanatula/eks-pod-identity-agent/pull/7, this PR had to be created since the approved one was against local. 

## What

Persist JWK public keys to disk after every successful JWKS fetch so the pod identity agent can validate tokens after restart when the apiserver is unreachable. When `refreshKeys` fails to reach the apiserver, it falls back to the last-known-good keys from the disk cache.

## Why

During control-plane outages, the agent currently loses all cached keys on restart. This means pods cannot authenticate until the apiserver recovers and keys are re-fetched. This change ensures cryptographic material survives restarts, improving availability for existing pods during outages.

## Design

`refreshKeys` is the single decision point for key loading:
1. Try apiserver → success → persist to disk + load into memory
2. Try apiserver → fail → fall back to disk cache → load into memory
3. Try apiserver → fail → disk also missing/corrupt → return error

Disk persistence is best-effort: a write failure does not block the agent from using in-memory keys.

### New files
- `internal/validation/jwk_store.go` — `writeJWKCache` (atomic write via temp+rename) and `readJWKCache`
- `internal/validation/jwk_store_test.go` — unit tests for the disk I/O functions

### Modified files
- `internal/validation/token_validator.go` — added `jwkCachePath` field, `loadKeysFromDisk` fallback, `persistKeys` helper

## Testing

### Unit tests (table-driven)
- `TestJWKDiskPersistence_WriteAndRead_RoundTrips` — write/read cycle preserves all key fields
- `TestReadJWKCache_ErrorCases` — corrupt file and missing file return descriptive errors
- `TestJWKDiskPersistence_FilePermissions_0600` — file written with 0600 permissions

### Integration tests (TokenValidator + disk)
- `TestRefreshKeys_DiskPersistence` (6 subtests):
  - apiserver up, persists to disk
  - apiserver up, auto-creates nested directory
  - apiserver up, disk write fails, keys still loaded into memory
  - apiserver down, falls back to disk cache
  - apiserver down, no disk cache, returns error
  - apiserver down, no cache path configured, returns error
- `TestRefreshKeys_AlreadyInFlight` — concurrent refresh rejected
- `TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache` — full lifecycle: fetch → persist → restart with apiserver down → validate token end-to-end using disk-cached keys

### Manual testing on live EKS cluster

Deployed to a test EKS cluster and verified end-to-end.

#### Steps

1. Built image, pushed to a test ECR repo, patched the `eks-pod-identity-agent` daemonset
2. Confirmed all pods rolled out and running
3. SSM into a node, found the agent container, verified the cache file in the container rootfs

#### Evidence

**Identify the agent container on the node:**

```
# ctr -n k8s.io containers ls | grep <test-image>
<container-id>    <ecr-repo>:<tag>    io.containerd.runc.v2
```

**Read the cache file from the container filesystem:**

Since the container uses a minimal base image (no shell), we access its rootfs directly via the containerd runtime path on the host:

```
# cat /run/containerd/io.containerd.runtime.v2.task/k8s.io/<container-id>/rootfs/run/eks-pod-identity-agent/jwks-cache.json
{"keys":[{"kty":"RSA","kid":"<redacted>","use":"sig","alg":"RS256","n":"<redacted>","e":"AQAB"}, ... (13 keys total)]}
```

**File permissions:**

```
-rw-------. 1 root root 5847 <timestamp> .../jwks-cache.json
```

#### How we know this is success

| What we checked | What it proves |
|-----------------|---------------|
| File exists at expected path | Agent called `writeJWKCache` after successfully fetching from the apiserver |
| Permissions are `-rw-------` (0600) | Atomic write sets correct restrictive permissions |
| Contents are valid JWKS JSON with multiple RSA keys | `JWKSet` struct serialized correctly; matches apiserver JWKS endpoint |
| File timestamp matches pod start time | Write happened on the first `refreshKeys` call during startup |
| Agent pods are Running (not CrashLooping) | Disk persistence code path has no panics or fatal errors |

Also checked:
* The average read/write latency of a mock 13 key 5.4KB file JWKS file - read ~186µs, write ~640µs (created a dummy method in the PIA that would read and write the file 100 times each, and measured the average latencies).

#### What this does NOT verify (covered by unit tests)

- Disk fallback when apiserver is unreachable — `TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache`
- Corrupt/missing file handling — `TestReadJWKCache_ErrorCases`
- Disk write failure graceful degradation — `TestRefreshKeys_DiskPersistence/disk_write_fails`
