### PR TITLE
Add audience validation for service account tokens

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -95,11 +95,12 @@ func createServers(cfg aws.Config) []*server.Server {
 	for i, ip := range bindHosts {
 		addr := fmt.Sprintf("%s:%d", ip, serverPort)
 		servers[i] = server.NewEksCredentialServer(addr, handlers.EksCredentialHandlerOpts{
-			Cfg:               cfg,
-			ClusterName:       clusterName,
-			CredentialRenewal: maxCredentialRenewal,
-			MaxCacheSize:      maxCacheSize,
-			RefreshQPS:        refreshQps,
+			Cfg:                cfg,
+			ClusterName:        clusterName,
+			CredentialRenewal:  maxCredentialRenewal,
+			MaxCacheSize:       maxCacheSize,
+			RefreshQPS:         refreshQps,
+			EndpointOverridden: overrideEksAuthEndpoint != "",
 		})
 	}
 

--- a/internal/validation/claims_validation.go
+++ b/internal/validation/claims_validation.go
@@ -12,6 +12,10 @@ import (
 
 const (
 	validKeyIDRegex = `^[0-9a-f]{40}$`
+	// expectedAudience is the audience injected by the EKS Pod Identity webhook into
+	// projected service account tokens.
+	// See: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/272b85d83305dfa6b519685dc104fe045d86f6c0/main.go#L84
+	expectedAudience = "pods.eks.amazonaws.com"
 )
 
 var (
@@ -20,7 +24,7 @@ var (
 
 // ValidateClaims checks that a pre-parsed JWT token has the necessary claims
 // to retrieve credentials. The token must have been parsed with jwt.MapClaims.
-func ValidateClaims(ctx context.Context, token *jwt.Token) error {
+func (tv *TokenValidator) ValidateClaims(ctx context.Context, token *jwt.Token) error {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
 		return fmt.Errorf("failed to extract claims")
@@ -31,6 +35,13 @@ func ValidateClaims(ctx context.Context, token *jwt.Token) error {
 	}
 	if err := validateKubernetesClaims(ctx, claims); err != nil {
 		return err
+	}
+	if !tv.EndpointOverridden {
+		// Only enforce audience when using the default EKS Auth service. Custom
+		// delegates (via --endpoint) may expect tokens with a different audience.
+		if err := validateAudience(claims); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -98,4 +109,31 @@ func requireNestedString(m map[string]interface{}, key, claimPath string) error 
 		return fmt.Errorf("missing or empty claim: %s", claimPath)
 	}
 	return nil
+}
+
+// validateAudience ensures the token's audience matches the EKS Pod Identity
+// service. Kubernetes allows pods to project service account tokens scoped to
+// different audiences (e.g., the API server or a third-party service). This
+// check prevents a token intended for another consumer from being presented to
+// the agent to obtain IAM credentials (a confused deputy attack).
+func validateAudience(claims jwt.MapClaims) error {
+	audRaw, ok := claims["aud"]
+	if !ok {
+		return fmt.Errorf("missing claim: aud")
+	}
+	// The JWT spec allows aud to be either a single string or an array of strings
+	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+	switch aud := audRaw.(type) {
+	case string:
+		if aud == expectedAudience {
+			return nil
+		}
+	case []interface{}:
+		for _, a := range aud {
+			if s, ok := a.(string); ok && s == expectedAudience {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("invalid audience: expected %s", expectedAudience)
 }

--- a/internal/validation/claims_validation_test.go
+++ b/internal/validation/claims_validation_test.go
@@ -42,16 +42,17 @@ func parseToken(t *testing.T, tokenString string) *jwt.Token {
 
 func TestValidateClaims(t *testing.T) {
 	tests := []struct {
-		name    string
-		token   string
-		wantErr bool
+		name               string
+		token              string
+		endpointOverridden bool
+		wantErr            bool
 	}{
-		{"all valid", test.CreateToken(t, goodConfig()), false},
+		{"all valid", test.CreateToken(t, goodConfig()), true, false},
 		{"bad kid only", test.CreateToken(t, func() test.TokenConfig {
 			c := goodConfig()
 			c.HeaderOverrides = map[string]interface{}{"kid": "INVALID"}
 			return c
-		}()), true},
+		}()), true, true},
 		{"bad k8s claims only", test.CreateToken(t, func() test.TokenConfig {
 			c := goodConfig()
 			c.Overrides["kubernetes.io"] = map[string]interface{}{
@@ -59,12 +60,23 @@ func TestValidateClaims(t *testing.T) {
 				// missing serviceaccount and pod
 			}
 			return c
-		}()), true},
+		}()), true, true},
+		{"wrong audience rejected", test.CreateToken(t, func() test.TokenConfig {
+			c := goodConfig()
+			c.Overrides["aud"] = "wrong-audience"
+			return c
+		}()), false, true},
+		{"wrong audience accepted when endpoint overridden", test.CreateToken(t, func() test.TokenConfig {
+			c := goodConfig()
+			c.Overrides["aud"] = "wrong-audience"
+			return c
+		}()), true, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			parsed := parseToken(t, tc.token)
-			err := ValidateClaims(context.Background(), parsed)
+			tv := &TokenValidator{EndpointOverridden: tc.endpointOverridden}
+			err := tv.ValidateClaims(context.Background(), parsed)
 			if tc.wantErr && err == nil {
 				t.Fatal("expected error, got nil")
 			} else if !tc.wantErr && err != nil {
@@ -141,3 +153,30 @@ func TestRequireNestedString_NilAndEmptyParams(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAudience(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  jwt.MapClaims
+		wantErr bool
+	}{
+		{"correct audience string", jwt.MapClaims{"aud": expectedAudience}, false},
+		{"correct audience in array", jwt.MapClaims{"aud": []interface{}{expectedAudience}}, false},
+		{"correct audience among multiple", jwt.MapClaims{"aud": []interface{}{"other", expectedAudience}}, false},
+		{"wrong audience", jwt.MapClaims{"aud": "wrong"}, true},
+		{"wrong audience array", jwt.MapClaims{"aud": []interface{}{"wrong"}}, true},
+		{"missing audience", jwt.MapClaims{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAudience(tc.claims)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			} else if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+

--- a/internal/validation/token_validator.go
+++ b/internal/validation/token_validator.go
@@ -22,10 +22,11 @@ type keyCache map[string]*cachedKey
 // TokenValidator provides deep JWT validation (claims + signature) using
 // a persistent public key cache fetched from the kube-apiserver.
 type TokenValidator struct {
-	keys            atomic.Value // stores keyCache, which maps key IDs (kid) to public keys
-	jwksSource      jwksProvider
-	refreshInFlight atomic.Bool
-	jwkCachePath    string // disk path for persisting JWKS between restarts
+	keys               atomic.Value // stores keyCache, which maps key IDs (kid) to public keys
+	jwksSource         jwksProvider
+	refreshInFlight    atomic.Bool
+	jwkCachePath       string // disk path for persisting JWKS between restarts
+	EndpointOverridden bool   // skip audience validation when endpoint is overridden
 }
 
 func NewTokenValidator(ctx context.Context) (*TokenValidator, error) {
@@ -78,7 +79,7 @@ func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.Ek
 		return errors.NewRequestValidationError(fmt.Sprintf("Service account token cannot be parsed: %v", err))
 	}
 
-	if err := ValidateClaims(ctx, parsedToken); err != nil {
+	if err := tv.ValidateClaims(ctx, parsedToken); err != nil {
 		return errors.NewRequestValidationError(fmt.Sprintf("Service account token failed claim validations: %v", err))
 	}
 	if err := tv.validateSignature(ctx, req.ServiceAccountToken, parsedToken); err != nil {

--- a/internal/validation/token_validator_test.go
+++ b/internal/validation/token_validator_test.go
@@ -133,6 +133,7 @@ func TestValidateToken(t *testing.T) {
 		Iat:    now,
 		Nbf:    now,
 		Overrides: map[string]interface{}{
+			"aud":           expectedAudience,
 			"sub":           "system:serviceaccount:default:my-sa",
 			"kubernetes.io": fullK8sClaim(),
 		},
@@ -145,10 +146,11 @@ func TestValidateToken(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		token    string
-		cacheKey *rsa.PublicKey // public key cached for signature verification
-		wantErr  bool
+		name               string
+		token              string
+		cacheKey           *rsa.PublicKey // public key cached for signature verification
+		endpointOverridden bool
+		wantErr            bool
 	}{
 		{
 			name:     "valid claims and valid signature",
@@ -174,12 +176,43 @@ func TestValidateToken(t *testing.T) {
 			cacheKey: &wrongKey.PublicKey,
 			wantErr:  true,
 		},
+		{
+			name: "wrong audience rejected",
+			token: test.CreateSignedToken(t, signingKey, test.TokenConfig{
+				Expiry: now.Add(time.Hour),
+				Iat:    now,
+				Nbf:    now,
+				Overrides: map[string]interface{}{
+					"aud":           "wrong.audience.com",
+					"sub":           "system:serviceaccount:default:my-sa",
+					"kubernetes.io": fullK8sClaim(),
+				},
+			}),
+			cacheKey: &signingKey.PublicKey,
+			wantErr:  true,
+		},
+		{
+			name: "wrong audience accepted when endpoint overridden",
+			token: test.CreateSignedToken(t, signingKey, test.TokenConfig{
+				Expiry: now.Add(time.Hour),
+				Iat:    now,
+				Nbf:    now,
+				Overrides: map[string]interface{}{
+					"aud":           "custom.audience.com",
+					"sub":           "system:serviceaccount:default:my-sa",
+					"kubernetes.io": fullK8sClaim(),
+				},
+			}),
+			cacheKey:           &signingKey.PublicKey,
+			endpointOverridden: true,
+			wantErr:            false,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			tv := &TokenValidator{}
+			tv := &TokenValidator{EndpointOverridden: tc.endpointOverridden}
 			tv.keys.Store(keyCache{test.DefaultKid: {key: tc.cacheKey, alg: "RS256"}})
 
 			err := tv.ValidateToken(context.Background(), &credentials.EksCredentialsRequest{
@@ -303,6 +336,7 @@ func TestValidateToken_KeyRefreshOnCacheMiss(t *testing.T) {
 	kid := func(i int) string { return fmt.Sprintf("%040x", i) }
 
 	validClaims := map[string]interface{}{
+		"aud":           expectedAudience,
 		"sub":           "system:serviceaccount:default:my-sa",
 		"kubernetes.io": fullK8sClaim(),
 	}
@@ -410,6 +444,7 @@ func TestValidateToken_K8sVersionGating(t *testing.T) {
 		Iat:    now,
 		Nbf:    now,
 		Overrides: map[string]interface{}{
+			"aud":           expectedAudience,
 			"sub":           "system:serviceaccount:default:my-sa",
 			"kubernetes.io": fullK8sClaim(),
 		},
@@ -653,6 +688,7 @@ func TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache(t *testin
 		Iat:    now,
 		Nbf:    now,
 		Overrides: map[string]interface{}{
+			"aud": expectedAudience,
 			"sub": "system:serviceaccount:default:my-sa",
 			"kubernetes.io": map[string]interface{}{
 				"namespace": "default",

--- a/pkg/handlers/eks_credential_handler.go
+++ b/pkg/handlers/eks_credential_handler.go
@@ -31,11 +31,12 @@ type EksCredentialHandler struct {
 }
 
 type EksCredentialHandlerOpts struct {
-	Cfg               aws.Config
-	ClusterName       string
-	CredentialRenewal time.Duration
-	MaxCacheSize      int
-	RefreshQPS        int
+	Cfg                aws.Config
+	ClusterName        string
+	CredentialRenewal  time.Duration
+	MaxCacheSize       int
+	RefreshQPS         int
+	EndpointOverridden bool
 }
 
 var (
@@ -52,6 +53,9 @@ func NewEksCredentialHandler(opts EksCredentialHandlerOpts) *EksCredentialHandle
 	if err != nil {
 		log := logger.FromContext(context.Background())
 		log.Infof("failed to initialize token validator: %v", err)
+	}
+	if tv != nil {
+		tv.EndpointOverridden = opts.EndpointOverridden
 	}
 
 	if opts.CredentialRenewal != 0 && opts.MaxCacheSize != 0 {


### PR DESCRIPTION
## What

Validates that the service account token's `aud` claim matches `pods.eks.amazonaws.com` before exchanging it for IAM credentials. This is the audience injected by the [Pod Identity webhook](https://github.com/aws/amazon-eks-pod-identity-webhook/blob/272b85d83305dfa6b519685dc104fe045d86f6c0/main.go#L84).

## Why

Prevents a confused deputy attack where a token projected for a different audience (e.g., the API server or a third-party service) is presented to the agent to obtain IAM credentials.

The check is skipped when `--endpoint` is overridden, since custom delegates may expect tokens with a different audience.

## Testing

- Unit tests for `validateAudience` covering string and array audience formats, wrong/missing audience
- `TestValidateClaims_AudienceSkippedWhenEndpointOverridden`: verifies the check is skipped when endpoint is overridden
- `TestValidateToken` (wrong audience rejected): full ValidateToken path rejects bad audience
- `TestValidateToken_WrongAudienceAcceptedWhenEndpointOverridden`: full ValidateToken path accepts bad audience when endpoint is overridden
- All existing tests pass (`go test ./...`, `go vet ./...`)