### PR TITLE
Block JWKS disk fallback and local validation on unsupported K8s versions

### DIFF
--- a/internal/credsretriever/refreshing_cache.go
+++ b/internal/credsretriever/refreshing_cache.go
@@ -233,7 +233,7 @@ func (r *cachedCredentialRetriever) tryServingFromCache(ctx context.Context,
 		return nil, false
 	}
 
-	// Validate the token 
+	// Validate the token
 	if err := tv.ValidateToken(ctx, request); err != nil {
 		log.Infof("Local token validation failed: %v, falling back to delegate", err)
 		promLocalValidation.WithLabelValues("failure").Inc()

--- a/internal/validation/apiserver_client.go
+++ b/internal/validation/apiserver_client.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"go.amzn.com/eks/eks-pod-identity-agent/internal/middleware/logger"
@@ -20,6 +21,9 @@ const (
 
 // minK8sVersion is the minimum Kubernetes version required for JWKS support.
 var minK8sVersion = utilversion.MajorMinor(1, 34)
+
+// ErrUnsupportedK8sVersion indicates the cluster is too old to serve reliable JWKS.
+var ErrUnsupportedK8sVersion = errors.New("kubernetes version does not support fetching public keys")
 
 // apiserverClient manages communication with the Kubernetes API server using client-go.
 type apiserverClient struct {
@@ -72,6 +76,53 @@ func (ac *apiserverClient) fetchPublicKeys(ctx context.Context) (*JWKSet, error)
 	return &jwkSet, nil
 }
 
+// fetchPublicKeysWithFallback tries the apiserver first, persists keys on success,
+// and falls back to the disk cache on network errors. If the version check fails,
+// no fallback is attempted.
+func (ac *apiserverClient) fetchPublicKeysWithFallback(ctx context.Context, cachePath string) (*JWKSet, error) {
+	log := logger.FromContext(ctx)
+
+	jwks, err := ac.fetchPublicKeys(ctx)
+	if err != nil {
+		// Version check failure means keys from any source are unreliable — don't fallback.
+		if errors.Is(err, ErrUnsupportedK8sVersion) {
+			return nil, err
+		}
+
+		// Network/transient failure — try disk cache.
+		cached, diskErr := loadJWKCacheFromDisk(cachePath)
+		if diskErr != nil {
+			log.Warnf("failed to load JWK cache from disk: %v", diskErr)
+			return nil, err
+		}
+		log.Warnf("apiserver fetch failed, loaded keys from disk cache: %v", err)
+		return cached, nil
+	}
+
+	persistJWKCacheToDisk(ctx, cachePath, jwks)
+	return jwks, nil
+}
+
+// loadJWKCacheFromDisk reads keys from the disk cache. Returns an error if no
+// cache path is configured or the file cannot be read.
+func loadJWKCacheFromDisk(cachePath string) (*JWKSet, error) {
+	if cachePath == "" {
+		return nil, fmt.Errorf("no cache path configured")
+	}
+	return readJWKCache(cachePath)
+}
+
+// persistJWKCacheToDisk writes the JWKSet to disk if a cache path is configured.
+func persistJWKCacheToDisk(ctx context.Context, cachePath string, jwks *JWKSet) {
+	if cachePath == "" {
+		return
+	}
+	if err := writeJWKCache(cachePath, jwks); err != nil {
+		log := logger.FromContext(ctx)
+		log.Warnf("failed to write JWK cache to disk: %v", err)
+	}
+}
+
 // checkK8sVersion verifies the API server is running Kubernetes >= 1.34.
 func (ac *apiserverClient) checkK8sVersion(ctx context.Context) error {
 	log := logger.FromContext(ctx)
@@ -94,7 +145,7 @@ func (ac *apiserverClient) checkK8sVersion(ctx context.Context) error {
 		return fmt.Errorf("unable to parse Kubernetes version: %w", err)
 	}
 	if !v.AtLeast(minK8sVersion) {
-		return fmt.Errorf("Kubernetes version does not support fetching public keys from the apiserver, apiserver is on version %d.%d", v.Major(), v.Minor())
+		return fmt.Errorf("%w: apiserver is on version %d.%d", ErrUnsupportedK8sVersion, v.Major(), v.Minor())
 	}
 
 	return nil

--- a/internal/validation/apiserver_client_test.go
+++ b/internal/validation/apiserver_client_test.go
@@ -187,3 +187,77 @@ func TestCheckK8sVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchPublicKeysWithFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		preSeedDisk bool
+		wantKeys    int
+		wantErr     bool
+	}{
+		{
+			name: "apiserver up, returns keys and persists to disk",
+			handler: versionedHandler(func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(JWKSet{Keys: []JWK{{Kid: "k1"}}})
+			}),
+			wantKeys: 1,
+		},
+		{
+			name: "apiserver down, falls back to disk",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				// version endpoint succeeds but JWKS fails
+				if r.URL.Path == "/version" {
+					json.NewEncoder(w).Encode(version.Info{Major: "1", Minor: "34"})
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			preSeedDisk: true,
+			wantKeys:    1,
+		},
+		{
+			name: "version too old, does NOT fall back to disk",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(version.Info{Major: "1", Minor: "33"})
+			},
+			preSeedDisk: true,
+			wantErr:     true,
+		},
+		{
+			name: "apiserver down, no disk cache, returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/version" {
+					json.NewEncoder(w).Encode(version.Info{Major: "1", Minor: "34"})
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			preSeedDisk: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			ac := newTestApiserverClient(srv)
+			cachePath := t.TempDir() + "/jwks-cache.json"
+
+			if tc.preSeedDisk {
+				g.Expect(writeJWKCache(cachePath, &JWKSet{Keys: []JWK{{Kid: "disk-key"}}})).To(Succeed())
+			}
+
+			jwks, err := ac.fetchPublicKeysWithFallback(context.Background(), cachePath)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(jwks.Keys).To(HaveLen(tc.wantKeys))
+			}
+		})
+	}
+}

--- a/internal/validation/token_validator.go
+++ b/internal/validation/token_validator.go
@@ -2,19 +2,20 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
 	"github.com/golang-jwt/jwt/v5"
 	"go.amzn.com/eks/eks-pod-identity-agent/internal/middleware/logger"
 	"go.amzn.com/eks/eks-pod-identity-agent/pkg/credentials"
-	"go.amzn.com/eks/eks-pod-identity-agent/pkg/errors"
+	pkgerrors "go.amzn.com/eks/eks-pod-identity-agent/pkg/errors"
 )
 
 // jwksProvider abstracts fetching a JWK set, allowing the API client to be
 // swapped for testing.
 type jwksProvider interface {
-	fetchPublicKeys(ctx context.Context) (*JWKSet, error)
+	fetchPublicKeysWithFallback(ctx context.Context, cachePath string) (*JWKSet, error)
 }
 
 type keyCache map[string]*cachedKey
@@ -71,29 +72,27 @@ func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.Ek
 	log := logger.FromContext(ctx)
 
 	if req.ServiceAccountToken == "" {
-		return errors.NewRequestValidationError("Service account token cannot be empty")
+		return pkgerrors.NewRequestValidationError("Service account token cannot be empty")
 	}
 
 	parsedToken, _, err := jwt.NewParser().ParseUnverified(req.ServiceAccountToken, jwt.MapClaims{})
 	if err != nil {
-		return errors.NewRequestValidationError(fmt.Sprintf("Service account token cannot be parsed: %v", err))
+		return pkgerrors.NewRequestValidationError(fmt.Sprintf("Service account token cannot be parsed: %v", err))
 	}
 
 	if err := tv.ValidateClaims(ctx, parsedToken); err != nil {
-		return errors.NewRequestValidationError(fmt.Sprintf("Service account token failed claim validations: %v", err))
+		return pkgerrors.NewRequestValidationError(fmt.Sprintf("Service account token failed claim validations: %v", err))
 	}
 	if err := tv.validateSignature(ctx, req.ServiceAccountToken, parsedToken); err != nil {
-		return errors.NewRequestValidationError(fmt.Sprintf("JWT signature validation failed: %v", err))
+		return pkgerrors.NewRequestValidationError(fmt.Sprintf("JWT signature validation failed: %v", err))
 	}
 
 	log.Debug("Token validation passed")
 	return nil
 }
 
-// refreshKeys attempts to fetch JWKS from the apiserver and load them into the
-// in-memory cache. On success, keys are also persisted to disk. If the apiserver
-// is unreachable, it falls back to the last-known-good keys from the disk cache,
-// ensuring the agent can continue validating tokens across restarts and outages.
+// refreshKeys attempts to fetch JWKS from the apiserver (with disk fallback for
+// transient errors) and loads them into the in-memory cache.
 func (tv *TokenValidator) refreshKeys(ctx context.Context) error {
 	if !tv.refreshInFlight.CompareAndSwap(false, true) {
 		return fmt.Errorf("key refresh already in progress")
@@ -102,42 +101,16 @@ func (tv *TokenValidator) refreshKeys(ctx context.Context) error {
 
 	log := logger.FromContext(ctx)
 	log.Infof("Public key cache refresh triggered")
-	jwks, err := tv.jwksSource.fetchPublicKeys(ctx)
+	jwks, err := tv.jwksSource.fetchPublicKeysWithFallback(ctx, tv.jwkCachePath)
 	if err != nil {
-		return tv.loadKeysFromDisk(ctx, err)
+		if errors.Is(err, ErrUnsupportedK8sVersion) {
+			tv.keys.Store(make(keyCache))
+		}
+		return err
 	}
 
-	tv.persistKeys(ctx, jwks)
 	tv.loadJWKSet(ctx, jwks)
 	return nil
-}
-
-// loadKeysFromDisk attempts to load keys from the disk cache when the apiserver
-// is unreachable. Returns the original fetch error if the disk fallback also fails.
-func (tv *TokenValidator) loadKeysFromDisk(ctx context.Context, fetchErr error) error {
-	log := logger.FromContext(ctx)
-	if tv.jwkCachePath == "" {
-		return fetchErr
-	}
-	cached, err := readJWKCache(tv.jwkCachePath)
-	if err != nil {
-		log.Warnf("failed to load JWK cache from disk: %v", err)
-		return fetchErr
-	}
-	log.Warnf("apiserver fetch failed, loaded keys from disk cache: %v", fetchErr)
-	tv.loadJWKSet(ctx, cached)
-	return nil
-}
-
-// persistKeys writes the JWKSet to disk for future fallback use.
-func (tv *TokenValidator) persistKeys(ctx context.Context, jwks *JWKSet) {
-	if tv.jwkCachePath == "" {
-		return
-	}
-	if err := writeJWKCache(tv.jwkCachePath, jwks); err != nil {
-		log := logger.FromContext(ctx)
-		log.Warnf("failed to write JWK cache to disk: %v", err)
-	}
 }
 
 // loadJWKSet parses a JWKSet and atomically replaces the key cache.

--- a/internal/validation/token_validator.go
+++ b/internal/validation/token_validator.go
@@ -16,6 +16,7 @@ import (
 // swapped for testing.
 type jwksProvider interface {
 	fetchPublicKeysWithFallback(ctx context.Context, cachePath string) (*JWKSet, error)
+	checkK8sVersion(ctx context.Context) error
 }
 
 type keyCache map[string]*cachedKey
@@ -68,11 +69,26 @@ func (tv *TokenValidator) RefreshKeys(ctx context.Context, token string) error {
 
 // ValidateToken performs claims validation and cryptographic signature
 // verification on the request's service account token.
-func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.EksCredentialsRequest) error {
+func (tv *TokenValidator) ValidateToken(ctx context.Context, req *credentials.EksCredentialsRequest) (err error) {
 	log := logger.FromContext(ctx)
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("panic during local token validation: %v", r)
+			err = fmt.Errorf("local validation panicked: %v", r)
+		}
+	}()
 
 	if req.ServiceAccountToken == "" {
 		return pkgerrors.NewRequestValidationError("Service account token cannot be empty")
+	}
+
+	if tv.jwksSource == nil {
+		return fmt.Errorf("jwksSource is nil, skipping local validation")
+	}
+
+	if err := tv.jwksSource.checkK8sVersion(ctx); err != nil {
+		return fmt.Errorf("version check failed, skipping local validation: %w", err)
 	}
 
 	parsedToken, _, err := jwt.NewParser().ParseUnverified(req.ServiceAccountToken, jwt.MapClaims{})

--- a/internal/validation/token_validator_test.go
+++ b/internal/validation/token_validator_test.go
@@ -33,6 +33,17 @@ func (c *channelJWKSProvider) fetchPublicKeys(_ context.Context) (*JWKSet, error
 	return c.jwks, nil
 }
 
+func (c *channelJWKSProvider) fetchPublicKeysWithFallback(ctx context.Context, cachePath string) (*JWKSet, error) {
+	jwks, err := c.fetchPublicKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cachePath != "" {
+		writeJWKCache(cachePath, jwks)
+	}
+	return jwks, nil
+}
+
 // rsaJWK builds a JWK entry from an RSA public key, used to populate mock JWKS responses.
 func rsaJWK(kid string, pub *rsa.PublicKey) JWK {
 	return JWK{
@@ -517,6 +528,25 @@ func (f *failingJWKSProvider) fetchPublicKeys(_ context.Context) (*JWKSet, error
 	return nil, fmt.Errorf("apiserver unreachable")
 }
 
+func (f *failingJWKSProvider) fetchPublicKeysWithFallback(ctx context.Context, cachePath string) (*JWKSet, error) {
+	_, err := f.fetchPublicKeys(ctx)
+	if cachePath == "" {
+		return nil, err
+	}
+	cached, diskErr := readJWKCache(cachePath)
+	if diskErr != nil {
+		return nil, err
+	}
+	return cached, nil
+}
+
+// versionFailingJWKSProvider simulates a version check failure — no disk fallback.
+type versionFailingJWKSProvider struct{}
+
+func (v *versionFailingJWKSProvider) fetchPublicKeysWithFallback(_ context.Context, _ string) (*JWKSet, error) {
+	return nil, fmt.Errorf("%w: apiserver is on version 1.33", ErrUnsupportedK8sVersion)
+}
+
 // TestRefreshKeys_DiskPersistence covers all interactions between refreshKeys and the
 // disk cache: persist on success, fallback on failure, graceful handling of write errors.
 func TestRefreshKeys_DiskPersistence(t *testing.T) {
@@ -638,6 +668,31 @@ func TestRefreshKeys_DiskPersistence(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRefreshKeys_VersionCheckFailure_SkipsDiskFallback verifies that when the
+// version check fails, refreshKeys does NOT load keys from disk and clears
+// any existing keys from memory.
+func TestRefreshKeys_VersionCheckFailure_SkipsDiskFallback(t *testing.T) {
+	g := NewWithT(t)
+	key := test.GenerateTestKey(t)
+	jwks := &JWKSet{Keys: []JWK{rsaJWK("kid-1", &key.PublicKey)}}
+	cachePath := filepath.Join(t.TempDir(), "jwks-cache.json")
+
+	// Pre-seed disk with keys
+	g.Expect(writeJWKCache(cachePath, jwks)).To(Succeed())
+
+	tv := &TokenValidator{jwksSource: &versionFailingJWKSProvider{}, jwkCachePath: cachePath}
+	// Pre-populate in-memory cache with a key
+	tv.keys.Store(keyCache{"existing-kid": {key: &key.PublicKey, alg: "RS256"}})
+
+	err := tv.refreshKeys(context.Background())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("does not support fetching public keys"))
+
+	// Existing keys must be cleared from memory
+	cache := tv.keys.Load().(keyCache)
+	g.Expect(cache).To(BeEmpty())
 }
 
 // TestRefreshKeys_AlreadyInFlight verifies that concurrent refresh attempts

--- a/internal/validation/token_validator_test.go
+++ b/internal/validation/token_validator_test.go
@@ -22,6 +22,15 @@ import (
 	"go.amzn.com/eks/eks-pod-identity-agent/pkg/credentials"
 )
 
+// noopJWKSProvider is a minimal jwksProvider that always succeeds with no keys.
+type noopJWKSProvider struct{}
+
+func (n *noopJWKSProvider) fetchPublicKeysWithFallback(_ context.Context, _ string) (*JWKSet, error) {
+	return &JWKSet{}, nil
+}
+
+func (n *noopJWKSProvider) checkK8sVersion(_ context.Context) error { return nil }
+
 // channelJWKSProvider signals on called when fetchPublicKeys is invoked.
 type channelJWKSProvider struct {
 	called chan struct{}
@@ -42,6 +51,10 @@ func (c *channelJWKSProvider) fetchPublicKeysWithFallback(ctx context.Context, c
 		writeJWKCache(cachePath, jwks)
 	}
 	return jwks, nil
+}
+
+func (c *channelJWKSProvider) checkK8sVersion(_ context.Context) error {
+	return nil
 }
 
 // rsaJWK builds a JWK entry from an RSA public key, used to populate mock JWKS responses.
@@ -223,7 +236,7 @@ func TestValidateToken(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			tv := &TokenValidator{EndpointOverridden: tc.endpointOverridden}
+			tv := &TokenValidator{EndpointOverridden: tc.endpointOverridden, jwksSource: &noopJWKSProvider{}}
 			tv.keys.Store(keyCache{test.DefaultKid: {key: tc.cacheKey, alg: "RS256"}})
 
 			err := tv.ValidateToken(context.Background(), &credentials.EksCredentialsRequest{
@@ -540,11 +553,31 @@ func (f *failingJWKSProvider) fetchPublicKeysWithFallback(ctx context.Context, c
 	return cached, nil
 }
 
+func (f *failingJWKSProvider) checkK8sVersion(_ context.Context) error {
+	return nil
+}
+
 // versionFailingJWKSProvider simulates a version check failure — no disk fallback.
 type versionFailingJWKSProvider struct{}
 
 func (v *versionFailingJWKSProvider) fetchPublicKeysWithFallback(_ context.Context, _ string) (*JWKSet, error) {
 	return nil, fmt.Errorf("%w: apiserver is on version 1.33", ErrUnsupportedK8sVersion)
+}
+
+func (v *versionFailingJWKSProvider) checkK8sVersion(_ context.Context) error {
+	return fmt.Errorf("%w: apiserver is on version 1.33", ErrUnsupportedK8sVersion)
+}
+
+func TestValidateToken_VersionCheckFailure(t *testing.T) {
+	g := NewWithT(t)
+	tv := &TokenValidator{jwksSource: &versionFailingJWKSProvider{}}
+	tv.keys.Store(make(keyCache))
+
+	err := tv.ValidateToken(context.Background(), &credentials.EksCredentialsRequest{
+		ServiceAccountToken: "some-token",
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("version check failed"))
 }
 
 // TestRefreshKeys_DiskPersistence covers all interactions between refreshKeys and the
@@ -765,4 +798,99 @@ func TestIntegration_AgentRestart_ApiserverDown_ValidatesFromDiskCache(t *testin
 		ServiceAccountToken: token,
 	})
 	g.Expect(err).ToNot(HaveOccurred())
+}
+
+// panicJWKSProvider panics when fetchPublicKeysWithFallback is called,
+// simulating an unexpected crash in the JWKS fetch path.
+type panicJWKSProvider struct{}
+
+func (p *panicJWKSProvider) fetchPublicKeysWithFallback(_ context.Context, _ string) (*JWKSet, error) {
+	panic("unexpected nil pointer in JWKS fetch")
+}
+
+func (p *panicJWKSProvider) checkK8sVersion(_ context.Context) error {
+	return nil
+}
+
+// TestValidateToken_PanicRecovery verifies that a panic anywhere in the
+// local validation path is recovered gracefully and returns an error
+// instead of crashing the goroutine.
+func TestValidateToken_PanicRecovery(t *testing.T) {
+	g := NewWithT(t)
+	now := time.Now()
+	signingKey := test.GenerateTestKey(t)
+
+	// Token with an unknown kid — forces a key refresh, which will panic
+	token := test.CreateSignedToken(t, signingKey, test.TokenConfig{
+		Expiry:          now.Add(time.Hour),
+		Iat:             now,
+		Nbf:             now,
+		HeaderOverrides: map[string]interface{}{"kid": "0000000000000000000000000000000000000001"},
+		Overrides: map[string]interface{}{
+			"aud":           expectedAudience,
+			"sub":           "system:serviceaccount:default:my-sa",
+			"kubernetes.io": fullK8sClaim(),
+		},
+	})
+
+	tv := &TokenValidator{jwksSource: &panicJWKSProvider{}}
+	tv.keys.Store(make(keyCache)) // empty cache — kid miss triggers refresh → panic
+
+	err := tv.ValidateToken(context.Background(), &credentials.EksCredentialsRequest{
+		ServiceAccountToken: token,
+	})
+
+	// Must return an error, not crash
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("panicked"))
+}
+
+// TestValidateToken_KidNotInJWKSAfterRefresh verifies that when the token's kid
+// is not in the PIA's cache and the apiserver returns keys that don't include
+// that kid, ValidateToken returns an error (triggering fallback to Auth Service).
+func TestValidateToken_KidNotInJWKSAfterRefresh(t *testing.T) {
+	g := NewWithT(t)
+	now := time.Now()
+
+	signingKey := test.GenerateTestKey(t)
+	otherKey := test.GenerateTestKey(t)
+
+	// Token signed with a kid that the apiserver won't return
+	tokenKid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	token := test.CreateSignedToken(t, signingKey, test.TokenConfig{
+		Expiry:          now.Add(time.Hour),
+		Iat:             now,
+		Nbf:             now,
+		HeaderOverrides: map[string]interface{}{"kid": tokenKid},
+		Overrides: map[string]interface{}{
+			"aud":           expectedAudience,
+			"sub":           "system:serviceaccount:default:my-sa",
+			"kubernetes.io": fullK8sClaim(),
+		},
+	})
+
+	// Apiserver returns a different kid — simulates stale/rotated keys
+	provider := &channelJWKSProvider{
+		called: make(chan struct{}, 1),
+		jwks:   &JWKSet{Keys: []JWK{rsaJWK("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", &otherKey.PublicKey)}},
+	}
+
+	tv := &TokenValidator{jwksSource: provider}
+	tv.keys.Store(make(keyCache)) // empty cache
+
+	err := tv.ValidateToken(context.Background(), &credentials.EksCredentialsRequest{
+		ServiceAccountToken: token,
+	})
+
+	// Refresh was triggered but kid still not found → error
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no matching key found"))
+
+	// Confirm refresh was actually called
+	select {
+	case <-provider.called:
+		// expected
+	default:
+		t.Fatal("expected JWKS refresh to be triggered")
+	}
 }


### PR DESCRIPTION
Prevents local token validation from running on unsupported Kubernetes versions by adding an early version check to `ValidateToken`. Also blocks JWKS disk cache fallback for those versions to avoid using stale keys.

Changes:
- Add `checkK8sVersion` to the `jwksProvider` interface
- Short-circuit `ValidateToken` with an error if the cluster version is unsupported (falls back to Auth Service)
- Add panic recovery in `ValidateToken` to prevent agent crashes from unexpected failures
- Tests for version check failure, panic recovery, and kid-not-found after refresh