### PR TITLE
feat(chart): make ServiceAccount configurable

### DIFF
--- a/charts/eks-pod-identity-agent/templates/_helpers.tpl
+++ b/charts/eks-pod-identity-agent/templates/_helpers.tpl
@@ -78,3 +78,19 @@ The eks-pod-identity-agent image to use
 {{- printf "%s/eks/eks-pod-identity-agent:%s" .Values.image.containerRegistry .Values.image.tag }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve the ServiceAccount name to set on the pod.
+  create=true,  name=""       -> chart-managed name (fullname template, no nameSuffix)
+  create=true,  name=<custom> -> custom name
+  create=false, name=<custom> -> reference a pre-existing SA by that name
+  create=false, name=""       -> empty string (caller omits serviceAccountName,
+                                 preserving the chart's pre-PR rendered output)
+*/}}
+{{- define "eks-pod-identity-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+  {{- default (include "eks-pod-identity-agent.fullname" (dict "Values" .Values "Release" .Release "Chart" .Chart)) .Values.serviceAccount.name }}
+{{- else -}}
+  {{- .Values.serviceAccount.name }}
+{{- end -}}
+{{- end }}

--- a/charts/eks-pod-identity-agent/templates/daemonset.yaml
+++ b/charts/eks-pod-identity-agent/templates/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
     spec:
       automountServiceAccountToken: true
       priorityClassName: {{ $top.Values.priorityClassName }}
+      {{- with (include "eks-pod-identity-agent.serviceAccountName" $top) }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       hostNetwork: true
       terminationGracePeriodSeconds: 30
       {{- with $top.Values.tolerations }}

--- a/charts/eks-pod-identity-agent/templates/serviceaccount.yaml
+++ b/charts/eks-pod-identity-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "eks-pod-identity-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "eks-pod-identity-agent.labels" (dict "Values" .Values "Release" .Release "Chart" .Chart) | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/eks-pod-identity-agent/values.yaml
+++ b/charts/eks-pod-identity-agent/values.yaml
@@ -180,6 +180,22 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+serviceAccount:
+  # Whether a ServiceAccount manifest should be created and assigned to the pod.
+  # Default false preserves the chart's current rendered output: no SA is created
+  # and no serviceAccountName is set on the pod, so admission resolves it to the
+  # namespace's "default" ServiceAccount.
+  create: false
+  # Annotations to add to the ServiceAccount when create is true (e.g. for
+  # IRSA / EKS Pod Identity associations on the agent itself, if desired).
+  annotations: {}
+  # The ServiceAccount name to use.
+  #   create=true,  name=""       -> chart-managed name (fullname template)
+  #   create=true,  name=<custom> -> create with the given name
+  #   create=false, name=<custom> -> reference a pre-existing SA in the namespace
+  #   create=false, name=""       -> omit serviceAccountName (default behaviour)
+  name: ""
+
 tolerations:
   - operator: Exists
 


### PR DESCRIPTION
Adds an opt-in serviceAccount block to the chart values so operators can either have the chart create a dedicated ServiceAccount or reference a pre-existing one. The DaemonSet sets serviceAccountName only when one of these is configured, keeping the default rendered manifest byte-identical to the prior release.

*Issue #, if available:* #157

*Description of changes:*

The DaemonSet currently runs as the namespace's `default` ServiceAccount because the chart hard-codes no `serviceAccountName`. Operators who need a dedicated SA have no override path short of forking the chart.

This PR adds an opt-in `serviceAccount` block to `values.yaml`:

| `create` | `name`        | Behaviour                                                                                  |
|----------|---------------|--------------------------------------------------------------------------------------------|
| `false`  | `""` (default)| **No change vs prior release** — no SA created, no `serviceAccountName` on the pod         |
| `false`  | `existing-sa` | No SA created; DaemonSet references the named pre-existing SA in the install namespace     |
| `true`   | `""`          | Chart creates an SA named after the fullname template and assigns it to the DaemonSet      |
| `true`   | `custom`      | Chart creates an SA named `custom` (with any configured annotations) and assigns it        |

Refs: #157

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
